### PR TITLE
[ feat ] 양식 관리 페이지 생성 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import ChangeRequestManagementPage from "./pages/admin/ChangeRequestManagementPa
 import UserManagementPage from "./pages/admin/UserManagementPage";
 import ResourceMonitoringPage from "./pages/admin/ResourceMonitoringPage";
 import ImageManagementPage from "./pages/admin/ImageManagementPage";
+import MessageTemplatePage from "./pages/admin/MessageTemplatePage";
 
 // Other Pages
 import AccountPage from "./pages/AccountPage";
@@ -197,6 +198,17 @@ const AppContent = () => {
           <ProtectedRoute requireAdmin>
             <DashboardLayout user={user} onLogout={logout}>
               <ImageManagementPage />
+            </DashboardLayout>
+          </ProtectedRoute>
+        }
+      />
+
+      <Route
+        path="/admin/message-templates"
+        element={
+          <ProtectedRoute requireAdmin>
+            <DashboardLayout user={user} onLogout={logout}>
+              <MessageTemplatePage />
             </DashboardLayout>
           </ProtectedRoute>
         }

--- a/src/components/Layout/Sidebar.jsx
+++ b/src/components/Layout/Sidebar.jsx
@@ -10,6 +10,7 @@ import {
   ClipboardDocumentListIcon,
   ArrowsRightLeftIcon,
   PhotoIcon,
+  EnvelopeIcon,
 } from "@heroicons/react/24/outline";
 
 const Sidebar = ({ isCollapsed, userRole = "USER" }) => {
@@ -42,6 +43,7 @@ const Sidebar = ({ isCollapsed, userRole = "USER" }) => {
     { name: "리소스 모니터링", href: "/admin/monitoring", icon: ChartBarIcon },
     { name: "컨테이너 관리", href: "/admin/containers", icon: ServerIcon },
     { name: "이미지 관리", href: "/admin/images", icon: PhotoIcon },
+    { name: "양식 관리", href: "/admin/message-templates", icon: EnvelopeIcon },
     { name: "시스템 설정", href: "/admin/settings", icon: CogIcon },
   ];
 

--- a/src/pages/admin/MessageTemplatePage.jsx
+++ b/src/pages/admin/MessageTemplatePage.jsx
@@ -17,6 +17,7 @@ const CATEGORIES = [
 const MessageTemplatePage = () => {
   const [templates, setTemplates] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
   const [alert, setAlert] = useState(null);
   const [editing, setEditing] = useState(null);
 
@@ -36,26 +37,49 @@ const MessageTemplatePage = () => {
     }
   };
 
-  const handleUpdate = async () => {
+  const closeModal = () => setEditing(null);
+
+  useEffect(() => {
     if (!editing) return;
-    const result = await updateMessage(editing.key, editing.value);
-    if (result.success) {
-      setAlert({ type: 'success', message: '메시지가 수정되었습니다.' });
-      setEditing(null);
-      fetchTemplates();
-    } else {
-      setAlert({ type: 'error', message: result.error });
+    const onKey = (e) => { if (e.key === 'Escape') closeModal(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [editing]);
+
+  const handleUpdate = async () => {
+    if (!editing || saving) return;
+    if (!editing.value.trim()) {
+      setAlert({ type: 'error', message: '메시지 내용을 입력해주세요.' });
+      return;
+    }
+    setSaving(true);
+    try {
+      const result = await updateMessage(editing.key, editing.value);
+      if (result.success) {
+        setAlert({ type: 'success', message: '메시지가 수정되었습니다.' });
+        closeModal();
+        fetchTemplates();
+      } else {
+        setAlert({ type: 'error', message: result.error });
+      }
+    } finally {
+      setSaving(false);
     }
   };
 
   const handleReset = async (key) => {
-    if (!window.confirm('기본값으로 초기화하시겠습니까?')) return;
-    const result = await resetMessage(key);
-    if (result.success) {
-      setAlert({ type: 'success', message: '기본값으로 복원되었습니다.' });
-      fetchTemplates();
-    } else {
-      setAlert({ type: 'error', message: result.error });
+    if (saving || !window.confirm('기본값으로 초기화하시겠습니까?')) return;
+    setSaving(true);
+    try {
+      const result = await resetMessage(key);
+      if (result.success) {
+        setAlert({ type: 'success', message: '기본값으로 복원되었습니다.' });
+        fetchTemplates();
+      } else {
+        setAlert({ type: 'error', message: result.error });
+      }
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -125,7 +149,7 @@ const MessageTemplatePage = () => {
                             편집
                           </Button>
                           {t.overridden && (
-                            <Button size="small" variant="secondary" onClick={() => handleReset(t.key)}>
+                            <Button size="small" variant="secondary" disabled={saving} onClick={() => handleReset(t.key)}>
                               초기화
                             </Button>
                           )}
@@ -141,8 +165,8 @@ const MessageTemplatePage = () => {
       )}
 
       {editing && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
-          <div className="bg-white w-full max-w-2xl p-6">
+        <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4" onClick={closeModal}>
+          <div className="bg-white w-full max-w-2xl p-6" onClick={e => e.stopPropagation()}>
             <h3 className="text-lg font-medium text-gray-900 mb-2">메시지 편집</h3>
             <p className="text-sm text-gray-500 font-mono mb-4">{editing.key}</p>
 
@@ -167,8 +191,10 @@ const MessageTemplatePage = () => {
             </div>
 
             <div className="flex justify-end gap-2">
-              <Button variant="secondary" onClick={() => setEditing(null)}>취소</Button>
-              <Button variant="primary" onClick={handleUpdate}>저장</Button>
+              <Button variant="secondary" onClick={closeModal} disabled={saving}>취소</Button>
+              <Button variant="primary" onClick={handleUpdate} disabled={saving || !editing.value.trim()}>
+                {saving ? '저장 중...' : '저장'}
+              </Button>
             </div>
           </div>
         </div>

--- a/src/pages/admin/MessageTemplatePage.jsx
+++ b/src/pages/admin/MessageTemplatePage.jsx
@@ -1,0 +1,180 @@
+import React, { useState, useEffect } from 'react';
+import { getMessages, updateMessage, resetMessage } from '../../services/messageService';
+import Card from '../../components/UI/Card';
+import Button from '../../components/UI/Button';
+import Alert from '../../components/UI/Alert';
+import Badge from '../../components/UI/Badge';
+
+const CATEGORIES = [
+  { label: '만료 알림', prefixes: ['notification.expired', 'notification.pre-expiry'] },
+  { label: '관리자 알림', prefixes: ['notification.admin'] },
+  { label: '승인 알림', prefixes: ['notification.approval'] },
+  { label: 'Pod 정리', prefixes: ['notification.pod'] },
+  { label: '사용자 관리', prefixes: ['notification.user'] },
+  { label: '시스템', prefixes: ['notification.monitor', 'notification.error'] },
+];
+
+const MessageTemplatePage = () => {
+  const [templates, setTemplates] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [alert, setAlert] = useState(null);
+  const [editing, setEditing] = useState(null);
+
+  useEffect(() => { fetchTemplates(); }, []);
+
+  const fetchTemplates = async () => {
+    setLoading(true);
+    try {
+      const result = await getMessages();
+      if (result.success) {
+        setTemplates(result.data);
+      } else {
+        setAlert({ type: 'error', message: result.error });
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleUpdate = async () => {
+    if (!editing) return;
+    const result = await updateMessage(editing.key, editing.value);
+    if (result.success) {
+      setAlert({ type: 'success', message: '메시지가 수정되었습니다.' });
+      setEditing(null);
+      fetchTemplates();
+    } else {
+      setAlert({ type: 'error', message: result.error });
+    }
+  };
+
+  const handleReset = async (key) => {
+    if (!window.confirm('기본값으로 초기화하시겠습니까?')) return;
+    const result = await resetMessage(key);
+    if (result.success) {
+      setAlert({ type: 'success', message: '기본값으로 복원되었습니다.' });
+      fetchTemplates();
+    } else {
+      setAlert({ type: 'error', message: result.error });
+    }
+  };
+
+  const grouped = CATEGORIES.map(cat => ({
+    ...cat,
+    items: templates.filter(t => cat.prefixes.some(p => t.key.startsWith(p))),
+  })).filter(g => g.items.length > 0);
+
+  // ponytail: catch uncategorized keys if backend adds new ones
+  const categorized = new Set(grouped.flatMap(g => g.items.map(i => i.key)));
+  const uncategorized = templates.filter(t => !categorized.has(t.key));
+  if (uncategorized.length) grouped.push({ label: '기타', items: uncategorized });
+
+  return (
+    <div className="p-6">
+      {alert && (
+        <div className="mb-4">
+          <Alert type={alert.type} message={alert.message} onClose={() => setAlert(null)} />
+        </div>
+      )}
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">양식 관리</h1>
+        <p className="text-gray-600 mt-1">알림 메시지 템플릿을 관리합니다.</p>
+      </div>
+
+      {loading ? (
+        <div className="text-center py-12">
+          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-brand-500"></div>
+          <p className="mt-2 text-gray-600">로딩 중...</p>
+        </div>
+      ) : templates.length === 0 ? (
+        <div className="text-center py-12 text-gray-500">등록된 메시지 템플릿이 없습니다.</div>
+      ) : (
+        <div className="space-y-6">
+          {grouped.map(group => (
+            <Card key={group.label}>
+              <h2 className="text-lg font-medium text-gray-900 mb-4">{group.label}</h2>
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-gray-200">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">키</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">현재 값</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">상태</th>
+                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">작업</th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white divide-y divide-gray-200">
+                    {group.items.map(t => (
+                      <tr key={t.key} className="hover:bg-gray-50">
+                        <td className="px-6 py-4 text-sm text-gray-900 font-mono whitespace-nowrap">{t.key}</td>
+                        <td className="px-6 py-4 text-sm text-gray-700 max-w-md">
+                          <p className="truncate">{t.currentValue}</p>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          <Badge variant={t.overridden ? 'warning' : 'default'}>
+                            {t.overridden ? '수정됨' : '기본값'}
+                          </Badge>
+                        </td>
+                        <td className="px-6 py-4 text-right whitespace-nowrap space-x-2">
+                          <Button
+                            size="small"
+                            variant="outline"
+                            onClick={() => setEditing({ key: t.key, value: t.currentValue, defaultValue: t.defaultValue })}
+                          >
+                            편집
+                          </Button>
+                          {t.overridden && (
+                            <Button size="small" variant="secondary" onClick={() => handleReset(t.key)}>
+                              초기화
+                            </Button>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {editing && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
+          <div className="bg-white w-full max-w-2xl p-6">
+            <h3 className="text-lg font-medium text-gray-900 mb-2">메시지 편집</h3>
+            <p className="text-sm text-gray-500 font-mono mb-4">{editing.key}</p>
+
+            {editing.defaultValue && editing.defaultValue !== editing.value && (
+              <div className="bg-gray-50 border-l-4 border-gray-300 p-3 mb-4">
+                <p className="text-xs font-medium text-gray-500 mb-1">기본값</p>
+                <p className="text-sm text-gray-700 whitespace-pre-wrap">{editing.defaultValue}</p>
+              </div>
+            )}
+
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-gray-700 mb-1">메시지 내용</label>
+              <textarea
+                className="w-full border border-gray-300 p-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                rows={5}
+                value={editing.value}
+                onChange={e => setEditing({ ...editing, value: e.target.value })}
+              />
+              <p className="text-xs text-gray-500 mt-1">
+                플레이스홀더: {'{0}'} = 사용자명, {'{1}'} = 서버명 등 (위치에 따라 다름)
+              </p>
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <Button variant="secondary" onClick={() => setEditing(null)}>취소</Button>
+              <Button variant="primary" onClick={handleUpdate}>저장</Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MessageTemplatePage;

--- a/src/services/messageService.js
+++ b/src/services/messageService.js
@@ -1,0 +1,50 @@
+import apiClient from './api.js';
+import { authService } from './authService.js';
+
+const authHeaders = () => {
+  const token = authService.getAccessToken();
+  if (!token) throw new Error("인증 토큰이 없습니다.");
+  return { accept: 'application/json;charset=UTF-8', Authorization: `Bearer ${token}` };
+};
+
+export const getMessages = async () => {
+  try {
+    const response = await apiClient.request('/api/admin/messages', {
+      method: 'GET',
+      headers: authHeaders(),
+    });
+    // ponytail: backend ApiResponse wraps in {status, message, data}
+    const data = response.data?.data ?? response.data;
+    return { success: true, data: Array.isArray(data) ? data : [] };
+  } catch (error) {
+    console.error('Error fetching messages:', error);
+    return { success: false, error: '메시지 템플릿 목록을 불러오는데 실패했습니다.' };
+  }
+};
+
+export const updateMessage = async (key, value) => {
+  try {
+    await apiClient.request(`/api/admin/messages/${key}`, {
+      method: 'PATCH',
+      headers: { ...authHeaders(), 'Content-Type': 'application/json;charset=UTF-8' },
+      body: JSON.stringify({ value }),
+    });
+    return { success: true };
+  } catch (error) {
+    console.error('Error updating message:', error);
+    return { success: false, error: '메시지 수정에 실패했습니다.' };
+  }
+};
+
+export const resetMessage = async (key) => {
+  try {
+    await apiClient.request(`/api/admin/messages/${key}`, {
+      method: 'DELETE',
+      headers: authHeaders(),
+    });
+    return { success: true };
+  } catch (error) {
+    console.error('Error resetting message:', error);
+    return { success: false, error: '메시지 초기화에 실패했습니다.' };
+  }
+};


### PR DESCRIPTION
   ## Summary

   - 관리자용 알림 메시지 템플릿 관리 페이지 신규 구현 (#13)
   - 백엔드 `GET/PATCH/DELETE /api/admin/messages` API 연동
   - UX 결함 수정 (#14): 더블클릭 방지, ESC/배경 클릭 모달 닫기, 빈 값 저장 방지

   ## 변경 파일

   | 파일 | 변경 |
   |------|------|
   | `src/services/messageService.js` | 신규 — API 호출 3개 (조회/수정/초기화) |
   | `src/pages/admin/MessageTemplatePage.jsx` | 신규 — 카테고리별 테이블 + 편집 모달 |
   | `src/App.jsx` | `/admin/message-templates` 라우트 추가 |
   | `src/components/Layout/Sidebar.jsx` | "양식 관리" 메뉴 항목 추가 |

   ## 주요 기능

   - 카테고리별 그룹 테이블 (만료/관리자/승인/Pod/사용자/시스템)
   - 인라인 편집 모달 (기본값 참조 표시, 플레이스홀더 안내)
   - 오버라이드 상태 뱃지 (수정됨/기본값)
   - 오버라이드 초기화 (기본값 복원)

   ## Test plan

   - [ ] 관리자 로그인 → 사이드바 "양식 관리" 메뉴 노출 확인
   - [ ] `/admin/message-templates` 접근 시 템플릿 목록 로딩
   - [ ] 편집 버튼 → 모달 열림, ESC/배경 클릭으로 닫힘
   - [ ] 메시지 수정 후 저장 → 뱃지 "수정됨" 전환
   - [ ] 초기화 버튼 → confirm 후 기본값 복원
   - [ ] 빈 값 입력 시 저장 버튼 비활성화

   Closes #13, Closes #14