### PR TITLE
fix: Docker 빌드 실패 수정 — pnpm-workspace.yaml 제외

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 node_modules
 dist
 .git
+pnpm-workspace.yaml
 .gitignore
 *.md
 .env

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,7 @@ jobs:
         if: failure()
         run: |
           echo "=== Recent Pod Logs ==="
-          kubectl logs -n ${{ env.K8S_NAMESPACE }} -l app=ailab-frontend --tail=100
+          kubectl logs -n ${{ env.K8S_NAMESPACE }} -l app=ailab-frontend --tail=100 || true
 
           echo "=== Pod Events ==="
-          kubectl get events -n ${{ env.K8S_NAMESPACE }} --sort-by='.lastTimestamp'
+          kubectl get events -n ${{ env.K8S_NAMESPACE }} --sort-by='.lastTimestamp' || true


### PR DESCRIPTION
## 요약
- **main 배포 빌드 실패 원인**: #21에서 추가된 `pnpm-workspace.yaml`(pnpm 11의 `onlyBuiltDependencies` allowlist)을 Dockerfile의 **pnpm@9**가 해석하지 못함 — `ERROR packages field missing or empty` → `pnpm build` 실패 (run 28799445430)
- **수정**: `.dockerignore`에 `pnpm-workspace.yaml` 추가. 이미지 빌드(pnpm 9)는 빌드 스크립트를 차단하지 않아 allowlist가 필요 없고, 로컬 개발(pnpm 11)은 그대로 allowlist 사용
- **부가**: 실패 진단 스텝의 `kubectl logs`가 kubelet(farm2 100.100.100.102:10250) 접속 거부로 또 실패해 원인을 가렸음 → `|| true` 내성 처리

## 검증
- 동일 Dockerfile로 로컬 `docker build` 통과 (pnpm@9 install → build → nginx 스테이지)
- 머지 시 자동 배포로 #21 변경분(DECS 콘솔 개편)이 실제 반영됨 — 현재 운영 pod는 구 이미지(rollout 미실행 상태)

🤖 Generated with [Claude Code](https://claude.com/claude-code)