### PR TITLE
fix: DECS 콘솔 QA 후속 수정 3건 — GPU 카드 구분·페이지네이션·빈 상태 문구

### DIFF
--- a/src/hooks/useDecsUserData.js
+++ b/src/hooks/useDecsUserData.js
@@ -25,6 +25,20 @@ function getStatusLabel(status) {
   return "거절됨";
 }
 
+function getGpuOptionTitle(gpuType) {
+  const resourceGroupName = gpuType.resourceGroupName ?? "GPU";
+  const serverName = gpuType.serverName ?? gpuType.nodeId ?? gpuType.rsgroupId;
+
+  return serverName ? `${resourceGroupName} — ${serverName}` : resourceGroupName;
+}
+
+function getGpuOptionDescription(gpuType) {
+  const description = gpuType.description ?? "";
+  const nodeLabel = gpuType.nodeId ? `노드 ${gpuType.nodeId}` : null;
+
+  return [description, nodeLabel].filter(Boolean).join(" · ");
+}
+
 function mapActivity(request) {
   const createdAt = request.createdAt ?? request.created_at;
 
@@ -103,8 +117,8 @@ export function useDecsUserData() {
         if (gpuTypes) {
           const options = gpuTypes.map((g) => ({
             id: String(g.rsgroupId),
-            title: g.resourceGroupName,
-            desc: g.description ?? "",
+            title: getGpuOptionTitle(g),
+            desc: getGpuOptionDescription(g),
             memory: g.ramGb ? `${g.ramGb} GB` : "—",
           }));
           if (options.length > 0) {

--- a/src/pages/decs-console/admin/ContainerManagement.jsx
+++ b/src/pages/decs-console/admin/ContainerManagement.jsx
@@ -2,11 +2,14 @@
 import React from "react";
 import { Table, Header, Container, StatusIndicator, Badge, Button, Input, Select, Pagination } from "../../../design-system";
 
+const PAGE_SIZE = 10;
+
 function ContainerManagement({ onOpenDetail, containers = [] }) {
   const all = containers;
   const [q, setQ] = React.useState("");
   const [statusFilter, setStatusFilter] = React.useState("all");
   const [sort, setSort] = React.useState({ col: null, desc: false });
+  const [currentPage, setCurrentPage] = React.useState(1);
 
   let rows = all.filter((c) =>
     (q === "" || c.name.includes(q) || c.user.includes(q)) &&
@@ -16,6 +19,16 @@ function ContainerManagement({ onOpenDetail, containers = [] }) {
     const f = sort.col.sortingField;
     rows = [...rows].sort((a, b) => String(a[f]).localeCompare(String(b[f])) * (sort.desc ? -1 : 1));
   }
+  const pagesCount = Math.max(1, Math.ceil(rows.length / PAGE_SIZE));
+  const pageRows = rows.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+
+  React.useEffect(() => {
+    setCurrentPage(1);
+  }, [q, statusFilter]);
+
+  React.useEffect(() => {
+    if (currentPage > pagesCount) setCurrentPage(pagesCount);
+  }, [currentPage, pagesCount]);
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-l)" }}>
@@ -48,7 +61,7 @@ function ContainerManagement({ onOpenDetail, containers = [] }) {
           density="compact" trackBy="id"
           sortingColumn={sort.col} sortingDescending={sort.desc}
           onSortingChange={({ sortingColumn, sortingDescending }) => setSort({ col: sortingColumn, desc: sortingDescending })}
-          items={rows}
+          items={pageRows}
           empty="조건에 맞는 컨테이너가 없습니다."
           columns={[
             { id: "name", header: "이름", sortingField: "name", cell: (c) => <a href="#" onClick={(e) => { e.preventDefault(); onOpenDetail(c); }} style={{ color: "var(--decs-text-link)", fontWeight: 600, textDecoration: "none" }}>{c.name}</a> },
@@ -59,7 +72,7 @@ function ContainerManagement({ onOpenDetail, containers = [] }) {
             { id: "expires", header: "만료", sortingField: "expires", cell: (c) => <span style={{ color: "var(--decs-text-secondary)" }}>{c.expires}</span> },
             { id: "actions", header: "", width: 90, cell: (c) => <Button variant="normal" onClick={() => onOpenDetail(c)}>상세</Button> },
           ]}
-          footer={<div style={{ display: "flex", justifyContent: "flex-end" }}><Pagination currentPage={1} pagesCount={4} onChange={() => {}} /></div>}
+          footer={rows.length > PAGE_SIZE ? <div style={{ display: "flex", justifyContent: "flex-end" }}><Pagination currentPage={currentPage} pagesCount={pagesCount} onChange={setCurrentPage} /></div> : null}
         />
       </Container>
     </div>

--- a/src/pages/decs-console/user/UserDashboard.jsx
+++ b/src/pages/decs-console/user/UserDashboard.jsx
@@ -30,7 +30,7 @@ function BigStatus({ onConnect, onExtend, onDetail, server }) {
 function UserDashboard({ onRequest, onConnect, onExtend, onDetail, userName, server, expiryDays, activities = [] }) {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-l)", maxWidth: 900, margin: "0 auto" }}>
-      <Header variant="h1" description={server ? "현재 GPU 상태를 확인하고 바로 접속할 수 있어요." : "아직 신청한 GPU가 없어요. 신청하면 이곳에서 바로 확인할 수 있어요."}>안녕하세요, {userName}님</Header>
+      <Header variant="h1" description="GPU 사용 현황과 최근 활동을 확인할 수 있어요.">안녕하세요, {userName}님</Header>
 
       {expiryDays != null ? (<Alert type="warning" header={`${expiryDays}일 뒤 사용 기간이 만료됩니다`} action={<Button variant="normal" onClick={onExtend}>연장하기</Button>}>
         만료되면 컨테이너가 정지되고 저장하지 않은 작업이 사라질 수 있어요. 미리 연장해 두세요.


### PR DESCRIPTION
## 요약
- **GPU 선택 카드 구분 불가 수정**: 위저드에서 동일 GPU 타입 카드 5장이 이름·설명까지 똑같이 렌더되던 문제. gpu-types 응답의 `resourceGroupName/serverName/nodeId`를 병합해 `RTX 2080 Ti Cluster — LAB · 노드 LAB2`처럼 표기 (26-07-07 QA 실측 발견)
- **컨테이너 목록 페이지네이션 실동작**: 고정 4페이지 no-op → 실제 row 수 기반 10개 단위 페이징
- **사용자 대시보드 빈 상태 문구 중복 제거**: 부제+카드 이중 표시 → 카드 한 곳만

## 검증
- `pnpm build` 통과, 수정본 preview 대상 **전체 18페이지 Playwright 스위프 전부 PASS, JS 에러 0** (공개 2 + user 7 + admin 9)
- GPU 카드 구분 표기 스크린샷 확인 완료
- QA 상세: wiki `admin_container/qa-farm-e2e-260707.md` 4차 실행 기록

🤖 Generated with [Claude Code](https://claude.com/claude-code)