### PR TITLE
fix: 신청 위저드 UX 개선 — Ubuntu 계정 필수 노출·이미지 필터 + 관리자 placeholder 정리

### DIFF
--- a/src/hooks/useDecsUserData.js
+++ b/src/hooks/useDecsUserData.js
@@ -34,6 +34,18 @@ function mapActivity(request) {
   };
 }
 
+function getImageDate(imageVersion) {
+  const match = String(imageVersion ?? "").match(/(\d{6})(?!.*\d{6})/);
+  return match ? Number(match[1]) : 0;
+}
+
+function sortImagesByLatest(a, b) {
+  const bImageId = Number(b.imageId ?? 0);
+  const aImageId = Number(a.imageId ?? 0);
+  if (bImageId !== aImageId) return bImageId - aImageId;
+  return getImageDate(b.imageVersion) - getImageDate(a.imageVersion);
+}
+
 export function useDecsUserData() {
   const [server, setServer] = useState(undefined);
   const [activities, setActivities] = useState(undefined);
@@ -120,7 +132,9 @@ export function useDecsUserData() {
       if (imagesResult.status === "fulfilled" && imagesResult.value?.status === 200) {
         const images = getArrayData(imagesResult.value);
         if (images) {
-          const options = images.map((im) => ({
+          const decsImages = images.filter((im) => im.imageName === "dguailab/decs");
+          const visibleImages = decsImages.length > 0 ? decsImages : images;
+          const options = [...visibleImages].sort(sortImagesByLatest).map((im) => ({
             value: String(im.imageId),
             label: [im.imageName, im.imageVersion].filter(Boolean).join(" "),
             description: im.description ?? undefined,

--- a/src/pages/decs-console/admin/AdminDashboard.jsx
+++ b/src/pages/decs-console/admin/AdminDashboard.jsx
@@ -36,7 +36,7 @@ function AdminDashboard({ onOpenContainers, containers = [], users = [] }) {
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1.4fr", gap: "var(--decs-space-l)", alignItems: "start" }}>
         <Container header={<Header variant="h2">GPU 클러스터 사용률</Header>}>
           <div style={{ color: "var(--decs-text-secondary)", fontSize: "var(--decs-fs-body-s)", padding: "16px 0", textAlign: "center" }}>
-            실시간 사용률은 추후 구현 예정입니다
+            사용률 데이터는 현재 표시되지 않습니다.
           </div>
         </Container>
 

--- a/src/pages/decs-console/admin/ContainerDetail.jsx
+++ b/src/pages/decs-console/admin/ContainerDetail.jsx
@@ -1,5 +1,5 @@
 // ContainerDetail — 섹션(Container+Header) · 스펙(KeyValuePairs) · 탭(개요/로그/이벤트)
-import { Container, Header, KeyValuePairs, Tabs, StatusIndicator, Badge, BreadcrumbGroup } from "../../../design-system";
+import { Container, Header, KeyValuePairs, Tabs, StatusIndicator, BreadcrumbGroup } from "../../../design-system";
 
 function ContainerDetail({ item, onBack }) {
   const c = item;
@@ -36,21 +36,20 @@ function ContainerDetail({ item, onBack }) {
 
   const logs = (
     <div style={{ color: "var(--decs-text-secondary)", fontSize: "var(--decs-fs-body-s)", padding: "16px 0", textAlign: "center" }}>
-      로그 스트림은 추후 구현 예정입니다
+      표시할 로그 데이터가 없습니다.
     </div>
   );
 
   const events = (
     <div style={{ color: "var(--decs-text-secondary)", fontSize: "var(--decs-fs-body-s)", padding: "16px 0", textAlign: "center" }}>
-      이벤트 타임라인은 추후 구현 예정입니다
+      표시할 이벤트 데이터가 없습니다.
     </div>
   );
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-m)" }}>
       <BreadcrumbGroup items={[{ text: "컨테이너", href: "#" }, { text: c.name }]} onFollow={(it) => { if (it.href) onBack(); }} />
-      <Header variant="h1"
-        actions={<Badge color="grey">작업 기능 추후 구현</Badge>}>
+      <Header variant="h1">
         <span style={{ display: "inline-flex", alignItems: "center", gap: 10 }}>{c.name}</span>
       </Header>
       <Tabs tabs={[

--- a/src/pages/decs-console/admin/ContainerManagement.jsx
+++ b/src/pages/decs-console/admin/ContainerManagement.jsx
@@ -23,8 +23,7 @@ function ContainerManagement({ onOpenDetail, containers = [] }) {
 
       <Container disablePadding header={
         <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-s)" }}>
-          <Header variant="h2" counter={`(${rows.length})`}
-            actions={<Badge color="grey">작업 기능 추후 구현</Badge>}>
+          <Header variant="h2" counter={`(${rows.length})`}>
             컨테이너
           </Header>
           <div style={{ display: "flex", gap: "var(--decs-space-s)" }}>

--- a/src/pages/decs-console/user/RequestWizard.jsx
+++ b/src/pages/decs-console/user/RequestWizard.jsx
@@ -14,18 +14,50 @@ function RequestWizard({ onCancel, onDone, gpuOptions: gpuOptionsProp, envOption
   const [submitting, setSubmitting] = React.useState(false);
   const [done, setDone] = React.useState(false);
   const [error, setError] = React.useState(null);
+  const [envErrors, setEnvErrors] = React.useState({});
 
   const purposeOptions = [
     { id: "basic", title: "기본 실험용", desc: "간단한 코드 검증과 소규모 실험" },
     { id: "train", title: "대용량 모델 학습용", desc: "큰 배치와 오랜 학습 시간이 필요해요" },
     { id: "infer", title: "추론 서버용", desc: "모델을 띄워 요청을 처리해요" },
   ];
-  const gpuOptions = gpuOptionsProp ?? [];
-  const envOptions = envOptionsProp ?? [];
+  const gpuOptions = React.useMemo(() => gpuOptionsProp ?? [], [gpuOptionsProp]);
+  const envOptions = React.useMemo(() => envOptionsProp ?? [], [envOptionsProp]);
+  const ubuntuUsernamePattern = /^[a-z][a-z0-9_-]{2,49}$/;
+  const ubuntuUsernameFormatError = ubuntuUsername && !ubuntuUsernamePattern.test(ubuntuUsername)
+    ? "소문자로 시작하고 소문자·숫자·_·-만 사용해 3~50자로 입력해주세요."
+    : null;
+  const ubuntuPasswordLengthError = ubuntuPassword && ubuntuPassword.length < 8
+    ? "비밀번호는 8자 이상 입력해주세요."
+    : null;
+  const ubuntuUsernameError = envErrors.ubuntuUsername || ubuntuUsernameFormatError;
+  const ubuntuPasswordError = envErrors.ubuntuPassword || ubuntuPasswordLengthError;
 
   React.useEffect(() => {
     if (!env && envOptions.length > 0) setEnv(String(envOptions[0].value));
   }, [env, envOptions]);
+
+  function validateDevelopmentStep() {
+    const nextErrors = {};
+    if (!ubuntuUsername) {
+      nextErrors.ubuntuUsername = "Ubuntu 사용자명을 입력해주세요.";
+    } else if (!ubuntuUsernamePattern.test(ubuntuUsername)) {
+      nextErrors.ubuntuUsername = "소문자로 시작하고 소문자·숫자·_·-만 사용해 3~50자로 입력해주세요.";
+    }
+    if (!ubuntuPassword) {
+      nextErrors.ubuntuPassword = "Ubuntu 비밀번호를 입력해주세요.";
+    } else if (ubuntuPassword.length < 8) {
+      nextErrors.ubuntuPassword = "비밀번호는 8자 이상 입력해주세요.";
+    }
+    setEnvErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  }
+
+  function handleNavigate(nextStep) {
+    setError(null);
+    if (step === 3 && nextStep > step && !validateDevelopmentStep()) return;
+    setStep(nextStep);
+  }
 
   if (done) {
     return (
@@ -78,14 +110,25 @@ function RequestWizard({ onCancel, onDone, gpuOptions: gpuOptionsProp, envOption
           <FormField label="기본 환경 (이미지)">
             <Select selectedValue={env} onChange={setEnv} options={envOptions} />
           </FormField>
+          <FormField label="Ubuntu 사용자명 (필수)" errorText={ubuntuUsernameError}>
+            <Input
+              value={ubuntuUsername}
+              onChange={(value) => { setUbuntuUsername(value); setEnvErrors((prev) => ({ ...prev, ubuntuUsername: null })); }}
+              placeholder="소문자·숫자, 3~50자 (SSH 로그인 계정)"
+              invalid={!!ubuntuUsernameError}
+            />
+          </FormField>
+          <FormField label="Ubuntu 비밀번호 (필수)" errorText={ubuntuPasswordError}>
+            <Input
+              value={ubuntuPassword}
+              onChange={(value) => { setUbuntuPassword(value); setEnvErrors((prev) => ({ ...prev, ubuntuPassword: null })); }}
+              placeholder="SSH 접속에 사용할 비밀번호"
+              type="password"
+              invalid={!!ubuntuPasswordError}
+            />
+          </FormField>
           <ExpandableSection headerText="고급 설정 보기" variant="container">
             <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-m)", paddingTop: 4 }}>
-              <FormField label="Ubuntu 사용자명">
-                <Input value={ubuntuUsername} onChange={setUbuntuUsername} />
-              </FormField>
-              <FormField label="Ubuntu 비밀번호">
-                <Input value={ubuntuPassword} onChange={setUbuntuPassword} type="password" />
-              </FormField>
               <FormField label="저장공간 (GiB)">
                 <Input value={volumeSizeGiB} onChange={setVolumeSizeGiB} type="number" />
               </FormField>
@@ -104,7 +147,7 @@ function RequestWizard({ onCancel, onDone, gpuOptions: gpuOptionsProp, envOption
             { label: "GPU", value: (gpuOptions.find((o) => o.id === gpu[0]?.id) || {}).title || "—" },
             { label: "사용 기간", value: period + "일" },
             { label: "개발 환경", value: envOptions.find((o) => o.value === env)?.label ?? env },
-            { label: "Ubuntu 사용자명", value: ubuntuUsername || "—" },
+            { label: "Ubuntu 사용자명", value: ubuntuUsername || <span style={{ color: "var(--decs-status-warning)", fontWeight: 700 }}>미입력</span> },
             { label: "저장공간", value: `${volumeSizeGiB || "—"} GiB` },
           ]} />
         </Container>
@@ -115,8 +158,17 @@ function RequestWizard({ onCancel, onDone, gpuOptions: gpuOptionsProp, envOption
   function submit() {
     const selectedPurpose = purposeOptions.find((o) => o.id === purpose[0]?.id);
     const selectedGpu = gpu[0];
-    if (!selectedPurpose || !selectedGpu || !env || !ubuntuUsername || !ubuntuPassword || !volumeSizeGiB) {
-      setError("필수 신청 정보를 모두 입력해주세요.");
+    const missingFields = [
+      !selectedPurpose ? "사용 목적" : null,
+      !selectedGpu ? "GPU" : null,
+      !env ? "개발 환경" : null,
+      !ubuntuUsername ? "Ubuntu 사용자명" : null,
+      !ubuntuPassword ? "Ubuntu 비밀번호" : null,
+      !volumeSizeGiB ? "저장공간" : null,
+    ].filter(Boolean);
+    const developmentValid = validateDevelopmentStep();
+    if (missingFields.length > 0 || !developmentValid) {
+      setError(`필수 신청 정보를 확인해주세요: ${missingFields.join(", ") || "Ubuntu 계정 정보"}`);
       return undefined;
     }
 
@@ -143,7 +195,7 @@ function RequestWizard({ onCancel, onDone, gpuOptions: gpuOptionsProp, envOption
       <Header variant="h1">GPU 신청</Header>
       {error ? <div style={{ marginBottom: "var(--decs-space-m)" }}><Alert type="error">{error}</Alert></div> : null}
       <Container>
-        <Wizard steps={steps} activeStepIndex={step} onNavigate={setStep} onCancel={onCancel} onSubmit={submit} submitLabel="신청하기" isLoadingNextStep={submitting} />
+        <Wizard steps={steps} activeStepIndex={step} onNavigate={handleNavigate} onCancel={onCancel} onSubmit={submit} submitLabel="신청하기" isLoadingNextStep={submitting} />
       </Container>
     </div>
   );


### PR DESCRIPTION
## 요약
QA(webapp-testing) 실측 발견 3건 수정.

- **Ubuntu 계정 필드 상시 노출·필수 검증** — SSH 로그인 계정(Ubuntu 사용자명/비밀번호)이 4단계 접힌 '고급 설정'에 숨어 선택처럼 보이고, 안 열고 최종 확인까지 도달(확인 페이지 `—`)하던 문제. 개발 환경 단계에 '(필수)'로 상시 노출, placeholder·username 규칙·비밀번호 8자 검증, 단계별 '다음' 차단, 확인 페이지 미입력 경고.
- **이미지 드롭다운 필터** — 레거시 더미(`cuda:*`)·오등록(`decs260627`) 이미지가 섞여 사용자가 안 뜨는 이미지를 고르던 문제. `dguailab/decs`만 노출하고 최신(현재 `cuda12.5-tf2.20-ubuntu22.04-260705`)을 기본값으로. 빈 결과 시 전체 폴백.
- **관리자 콘솔 placeholder 정리** — '작업 기능 추후 구현' 배지, '실시간 사용률 추후 구현 예정' 문구 등 미완성 노출 제거/담백화.

## 검증
- `pnpm build` 통과. eslint 통과.
- webapp-testing 재검증: 4단계에 Ubuntu 필드 상시 노출('필수' 라벨·placeholder), 빈 값으로 '다음' 시 인라인 오류로 차단('Ubuntu 사용자명을 입력해주세요.'), 이미지 기본값이 최신 DECS(260705)로 표시, 레거시 cuda 미노출 — 스크린샷 확인.

## 참고
- 260705는 260627 + 커밋 `b2870c7`(Kerberos 홈 체크 수정 + Chrome). admin_be에 260705 등록 완료(id 52).
- QA 상세: wiki `admin_container/qa-farm-e2e-260707.md`, 포트 맵: `inventory/port-policy.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)