### PR TITLE
feat: 상단바 관리자/사용자 전환 세그먼트 토글

### DIFF
--- a/src/components/RoleSwitch.jsx
+++ b/src/components/RoleSwitch.jsx
@@ -1,0 +1,38 @@
+// 관리자/사용자 콘솔 전환 세그먼트 토글 — 상단바(어두운 배경) 전용, 관리자에게만 노출
+import { useNavigate } from "react-router-dom";
+
+const SEGMENTS = [
+  { key: "admin", label: "관리자", href: "/decs/admin" },
+  { key: "user", label: "사용자", href: "/decs/user" },
+];
+
+export default function RoleSwitch({ current }) {
+  const navigate = useNavigate();
+  return (
+    <div style={{ display: "inline-flex", background: "rgba(255,255,255,0.15)", borderRadius: "9999px", padding: "2px", marginRight: "var(--decs-space-xs)" }}>
+      {SEGMENTS.map((s) => {
+        const active = s.key === current;
+        return (
+          <button
+            key={s.key}
+            onClick={() => { if (!active) navigate(s.href); }}
+            aria-pressed={active}
+            style={{
+              border: 0,
+              cursor: active ? "default" : "pointer",
+              padding: "3px 12px",
+              borderRadius: "9999px",
+              fontFamily: "var(--decs-font-base)",
+              fontSize: "var(--decs-fs-body-s)",
+              fontWeight: active ? "var(--decs-fw-bold)" : "var(--decs-fw-regular)",
+              background: active ? "#fff" : "none",
+              color: active ? "var(--decs-grey-900)" : "rgba(255,255,255,0.85)",
+            }}
+          >
+            {s.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/design-system/components/navigation/TopNavigation.jsx
+++ b/src/design-system/components/navigation/TopNavigation.jsx
@@ -4,7 +4,7 @@ import { Icon } from "../icons/Icon.jsx";
 /**
  * TopNavigation — the global top bar: brand identity on the left, utility
  * actions (notifications, density, user menu) on the right.
- * utilities: [{ type:"button", text?, iconName?, badge?, onClick } | { type:"menu", text, iconName?, items:[] }]
+ * utilities: [{ type:"button", text?, iconName?, badge?, onClick } | { type:"menu", text, iconName?, items:[] } | { type:"custom", content:<node> }]
  */
 export function TopNavigation({ identity, utilities = [], style }) {
   const [openMenu, setOpenMenu] = React.useState(null);
@@ -22,7 +22,9 @@ export function TopNavigation({ identity, utilities = [], style }) {
         <span style={{ fontSize: "var(--decs-fs-heading-s)", fontWeight: "var(--decs-fw-bold)" }}>{identity?.title}</span>
       </a>
       <div style={{ display: "flex", alignItems: "center", gap: "var(--decs-space-xxs)" }}>
-        {utilities.map((u, i) => (
+        {utilities.map((u, i) => u.type === "custom" ? (
+          <div key={i} style={{ display: "flex", alignItems: "center" }}>{u.content}</div>
+        ) : (
           <div key={i} style={{ position: "relative" }}>
             <button onClick={() => u.type === "menu" ? setOpenMenu(openMenu === i ? null : i) : u.onClick?.()} aria-label={u.ariaLabel || (typeof u.text === "string" ? u.text : undefined)}
               style={{ display: "inline-flex", alignItems: "center", gap: "6px", position: "relative",

--- a/src/pages/decs-console/admin/AdminConsoleApp.jsx
+++ b/src/pages/decs-console/admin/AdminConsoleApp.jsx
@@ -13,6 +13,7 @@ import ResourceMonitoringPage from "../../admin/ResourceMonitoringPage";
 import ImageManagementPage from "../../admin/ImageManagementPage";
 import MessageTemplatePage from "../../admin/MessageTemplatePage";
 import donggukLogo from "../../../assets/dongguk_university_logo.svg";
+import RoleSwitch from "../../../components/RoleSwitch";
 
 function AdminConsoleApp() {
   const location = useLocation();
@@ -41,14 +42,13 @@ function AdminConsoleApp() {
 
   const displayName = user?.name || user?.email || "사용자";
   const utilities = [
+    { type: "custom", content: <RoleSwitch current="admin" /> },
     { iconName: "bell", ariaLabel: "알림", badge: 3 },
     {
       type: "menu",
       iconName: "user-circle",
       text: displayName,
       items: [
-        { text: "사용자 화면으로 전환", onClick: () => navigate("/decs/user") },
-        { type: "divider" },
         { text: "로그아웃", onClick: () => { logout(); navigate("/login"); } },
       ],
     },

--- a/src/pages/decs-console/user/UserPortalApp.jsx
+++ b/src/pages/decs-console/user/UserPortalApp.jsx
@@ -12,6 +12,7 @@ import MyChangeRequestsPage from "../../MyChangeRequestsPage";
 import AccountPage from "../../AccountPage";
 import ResourceMonitoringPage from "../../ResourceMonitoringPage";
 import donggukLogo from "../../../assets/dongguk_university_logo.svg";
+import RoleSwitch from "../../../components/RoleSwitch";
 
 function UserPortalApp() {
   const location = useLocation();
@@ -39,14 +40,13 @@ function UserPortalApp() {
   };
 
   const utilities = [
+    ...(isAdmin ? [{ type: "custom", content: <RoleSwitch current="user" /> }] : []),
     { iconName: "bell", ariaLabel: "알림", badge: 1 },
     {
       type: "menu",
       iconName: "user-circle",
       text: userName,
       items: [
-        ...(isAdmin ? [{ text: "관리자 콘솔로", onClick: () => navigate("/decs/admin") }] : []),
-        ...(isAdmin ? [{ type: "divider" }] : []),
         { text: "로그아웃", onClick: () => { logout(); navigate("/login"); } },
       ],
     },


### PR DESCRIPTION
## 요약
- 관리자/사용자 화면 전환이 프로필 드롭다운 안에 숨어 있어 직관적이지 않던 것을, 상단바에 상시 노출되는 `관리자 | 사용자` 세그먼트 토글로 교체
- 현재 모드가 하이라이트되어 어느 콘솔에 있는지 즉시 확인 가능, 전환은 한 클릭
- 사용자 포털에서는 ADMIN 권한일 때만 토글 노출 — 일반 사용자 화면 변화 없음

## 변경
- `src/components/RoleSwitch.jsx` 신규
- `TopNavigation.jsx` — utilities `type: "custom"` 렌더링 지원 추가
- `AdminConsoleApp.jsx` / `UserPortalApp.jsx` — 토글 적용, 기존 드롭다운 전환 메뉴 제거

## 검증
- `vite build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)