### PR TITLE
fix: 내 컨테이너 접속정보 미표시 수정 + 다중 컨테이너 목록 + 연장 모달 직결

### DIFF
--- a/src/hooks/useDecsUserData.js
+++ b/src/hooks/useDecsUserData.js
@@ -82,8 +82,30 @@ function buildGpuOptions(gpuTypes) {
   }));
 }
 
+function buildServerVm(dto) {
+  const vm = mapUserServer(dto);
+  const serverName = dto.resourceGroup?.serverName ?? "";
+
+  return {
+    requestId: vm.id,
+    ubuntuUsername: dto.ubuntuUsername ?? "—",
+    image: vm.image,
+    expiresAt: vm.expiresAt,
+    gpuName: serverName || vm.gpuName,
+    gpuSpec: serverName ? vm.gpuName : null,
+    statusType: vm.statusType ?? "success",
+    statusLabel: vm.statusLabel ?? "사용 가능",
+    jobBadge: `내 서버 · ${serverName || vm.gpuName}`,
+    jobTitle: "내 서버",
+    daysLeft: vm.daysLeft ?? daysLeft(dto.expiresAt),
+    expiresText: formatExpiresText(vm.expiresAt),
+    sshCommand: vm.sshCommand || "—",
+    jupyterUrl: vm.jupyterUrl || "—",
+  };
+}
+
 export function useDecsUserData() {
-  const [server, setServer] = useState(undefined);
+  const [servers, setServers] = useState(undefined);
   const [activities, setActivities] = useState(undefined);
   const [gpuOptions, setGpuOptions] = useState(undefined);
   const [envOptions, setEnvOptions] = useState(undefined);
@@ -105,27 +127,11 @@ export function useDecsUserData() {
       let hasError = false;
 
       if (serversResult.status === "fulfilled" && serversResult.value?.status === 200) {
-        const servers = getArrayData(serversResult.value);
-        if (servers && servers.length > 0) {
-          const dto = servers[0];
-          const vm = mapUserServer(dto);
-
-          const serverName = dto.resourceGroup?.serverName ?? "";
-          setServer({
-            requestId: vm.id,
-            expiresAt: vm.expiresAt,
-            gpuName: serverName || vm.gpuName,
-            gpuSpec: serverName ? vm.gpuName : null,
-            statusType: vm.statusType ?? "success",
-            statusLabel: vm.statusLabel ?? "사용 가능",
-            jobBadge: `내 서버 · ${serverName || vm.gpuName}`,
-            jobTitle: "내 서버",
-            daysLeft: vm.daysLeft ?? daysLeft(dto.expiresAt),
-            expiresText: formatExpiresText(vm.expiresAt),
-            sshCommand: vm.sshCommand || "—",
-            jupyterUrl: vm.jupyterUrl || "—",
-          });
-        } else if (!servers) {
+        const serverDtos = getArrayData(serversResult.value);
+        if (serverDtos) {
+          // 만료 임박 순 — 대시보드 단일 카드와 만료 경고는 가장 급한 컨테이너 기준
+          setServers(serverDtos.map(buildServerVm).sort((a, b) => a.daysLeft - b.daysLeft));
+        } else {
           hasError = true;
         }
       } else {
@@ -212,10 +218,11 @@ export function useDecsUserData() {
     };
   }, []);
 
+  const server = servers?.[0];
   const expiryDays =
     server && server.daysLeft != null && server.daysLeft <= 7
       ? server.daysLeft
       : null;
 
-  return { server, expiryDays, activities, gpuOptions, envOptions, groupOptions, error };
+  return { server, servers, expiryDays, activities, gpuOptions, envOptions, groupOptions, error };
 }

--- a/src/pages/decs-console/admin/AdminConsoleApp.jsx
+++ b/src/pages/decs-console/admin/AdminConsoleApp.jsx
@@ -44,7 +44,6 @@ function AdminConsoleApp() {
   const utilities = [
     { type: "custom", content: <RoleSwitch current="admin" /> },
     { text: t("common.language"), onClick: () => i18n.changeLanguage(i18n.language === "en" ? "ko" : "en") },
-    { iconName: "bell", ariaLabel: t("common.notifications"), badge: 3 },
     {
       type: "menu",
       iconName: "user-circle",

--- a/src/pages/decs-console/user/UserContainerDetail.jsx
+++ b/src/pages/decs-console/user/UserContainerDetail.jsx
@@ -1,16 +1,31 @@
 // UserContainerDetail — 접속·상태 이해 (친절한 문구 + 복사 가능한 접속 정보)
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { Container, Header, KeyValuePairs, StatusIndicator, Button, Alert, ExpandableSection, Badge, FormField, Input, Modal } from "../../../design-system";
 
 function UserContainerDetail({ onBack, onExtend, servers = [] }) {
+  const location = useLocation();
+  const navigate = useNavigate();
   const [selectedId, setSelectedId] = useState(null);
   const [extendOpen, setExtendOpen] = useState(false);
   const [expiresDate, setExpiresDate] = useState("");
   const [reason, setReason] = useState("");
   const [extendError, setExtendError] = useState(null);
   const [submitting, setSubmitting] = useState(false);
+  const [autoExtended, setAutoExtended] = useState(false);
 
   const server = servers.find((s) => s.requestId === selectedId) ?? servers[0];
+
+  // 대시보드 연장 버튼 경유(location.state.extend) 시 서버 로드 후 모달 자동 오픈
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- openExtension은 매 렌더 새로 생성, autoExtended 가드로 1회만 실행
+  useEffect(() => {
+    if (location.state?.extend && server && !autoExtended) {
+      setAutoExtended(true);
+      // history.state를 비워 새로고침 시 모달이 재오픈되지 않게 함
+      navigate(location.pathname, { replace: true, state: null });
+      openExtension();
+    }
+  }, [location.state, server, autoExtended]);
 
   function openExtension() {
     const suggested = new Date(server.expiresAt);

--- a/src/pages/decs-console/user/UserContainerDetail.jsx
+++ b/src/pages/decs-console/user/UserContainerDetail.jsx
@@ -2,12 +2,15 @@
 import { useState } from "react";
 import { Container, Header, KeyValuePairs, StatusIndicator, Button, Alert, ExpandableSection, Badge, FormField, Input, Modal } from "../../../design-system";
 
-function UserContainerDetail({ onBack, onExtend, server }) {
+function UserContainerDetail({ onBack, onExtend, servers = [] }) {
+  const [selectedId, setSelectedId] = useState(null);
   const [extendOpen, setExtendOpen] = useState(false);
   const [expiresDate, setExpiresDate] = useState("");
   const [reason, setReason] = useState("");
   const [extendError, setExtendError] = useState(null);
   const [submitting, setSubmitting] = useState(false);
+
+  const server = servers.find((s) => s.requestId === selectedId) ?? servers[0];
 
   function openExtension() {
     const suggested = new Date(server.expiresAt);
@@ -32,7 +35,7 @@ function UserContainerDetail({ onBack, onExtend, server }) {
     setSubmitting(true);
     setExtendError(null);
     try {
-      await onExtend({ expiresAt: `${expiresDate}T23:59:59`, reason: reason.trim() });
+      await onExtend({ requestId: server.requestId, expiresAt: `${expiresDate}T23:59:59`, reason: reason.trim() });
     } catch (error) {
       setExtendError(error.message || "기간 연장 요청에 실패했어요. 잠시 후 다시 시도해주세요.");
     } finally {
@@ -59,8 +62,43 @@ function UserContainerDetail({ onBack, onExtend, server }) {
       <div>
         <Button variant="link" iconName="arrow-left" onClick={onBack}>대시보드</Button>
         <Header variant="h1" actions={<StatusIndicator type={server.statusType}>{server.statusLabel}</StatusIndicator>}>{server.jobTitle}</Header>
-        <Badge color="brand">{server.gpuName}</Badge>
+        <div style={{ display: "flex", gap: 8 }}>
+          <Badge color="brand">{server.gpuName}</Badge>
+          <Badge color="grey">{server.ubuntuUsername}</Badge>
+        </div>
       </div>
+
+      {servers.length > 1 ? (
+        <Container header={<Header variant="h2" description="컨테이너를 선택하면 아래에 접속 정보가 표시됩니다">내 컨테이너 목록</Header>}>
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-s)" }}>
+            {servers.map((item) => (
+              <div
+                key={item.requestId}
+                role="button"
+                tabIndex={0}
+                onClick={() => setSelectedId(item.requestId)}
+                onKeyDown={(event) => { if (event.key === "Enter" || event.key === " ") setSelectedId(item.requestId); }}
+                style={{
+                  display: "flex", justifyContent: "space-between", alignItems: "center",
+                  padding: "12px 16px", cursor: "pointer",
+                  borderRadius: "var(--decs-radius-input)",
+                  border: item.requestId === server.requestId
+                    ? "2px solid var(--decs-brand-300)"
+                    : "1px solid var(--decs-border-container)",
+                }}
+              >
+                <div>
+                  <div style={{ fontWeight: 600, color: "var(--decs-text-heading)" }}>{item.ubuntuUsername}</div>
+                  <div style={{ fontSize: "var(--decs-fs-body-s)", color: "var(--decs-text-secondary)" }}>
+                    {item.gpuName}{item.gpuSpec ? ` · ${item.gpuSpec}` : ""} · {item.expiresText}
+                  </div>
+                </div>
+                <StatusIndicator type={item.statusType}>{item.statusLabel}</StatusIndicator>
+              </div>
+            ))}
+          </div>
+        </Container>
+      ) : null}
 
       <Container header={<Header variant="h2" description="터미널에 아래 명령을 붙여넣어 접속하세요">접속 정보</Header>}>
         <KeyValuePairs columns={1} items={[
@@ -71,7 +109,7 @@ function UserContainerDetail({ onBack, onExtend, server }) {
           <ExpandableSection headerText="Jupyter로 접속하기">
             <KeyValuePairs columns={1} items={[
               { label: "주소", value: server.jupyterUrl, copyable: true },
-              { label: "토큰", value: "대시보드 알림에서 확인할 수 있어요" },
+              { label: "토큰", value: "승인 안내 메일에서 확인할 수 있어요" },
             ]} />
           </ExpandableSection>
         </div>

--- a/src/pages/decs-console/user/UserPortalApp.jsx
+++ b/src/pages/decs-console/user/UserPortalApp.jsx
@@ -96,7 +96,7 @@ function UserPortalApp() {
         {error ? <div style={{ marginBottom: "var(--decs-space-m)" }}><Flashbar items={[{ id: "decs-user-data", type: "warning", header: error, dismissible: false }]} /></div> : null}
         {submitError ? <div style={{ marginBottom: "var(--decs-space-m)" }}><Flashbar items={[{ id: "decs-request-submit", type: "error", header: submitError, dismissible: false }]} /></div> : null}
         <Routes>
-          <Route index element={<UserDashboard userName={userName} server={server} expiryDays={expiryDays} activities={activities ?? []} onRequest={() => navigate("/user/request")} onConnect={() => navigate("/user/container")} onExtend={() => navigate("/user/container")} onDetail={() => navigate("/user/container")} />} />
+          <Route index element={<UserDashboard userName={userName} server={server} expiryDays={expiryDays} activities={activities ?? []} onRequest={() => navigate("/user/request")} onConnect={() => navigate("/user/container")} onExtend={() => navigate("/user/container", { state: { extend: true } })} onDetail={() => navigate("/user/container")} />} />
           <Route path="request" element={<RequestWizard onCancel={() => navigate("/user")} onDone={() => navigate("/user/requests")} gpuOptions={gpuOptions ?? []} envOptions={envOptions ?? []} groupOptions={groupOptions ?? []} onSubmit={submitRequest} />} />
           <Route path="container" element={<UserContainerDetail onBack={() => navigate("/user")} onExtend={submitExtension} servers={servers ?? []} />} />
           <Route path="requests" element={<RequestStatusPage />} />

--- a/src/pages/decs-console/user/UserPortalApp.jsx
+++ b/src/pages/decs-console/user/UserPortalApp.jsx
@@ -20,7 +20,7 @@ function UserPortalApp() {
   const navigate = useNavigate();
   const { user, logout } = useAuth();
   const { t, i18n } = useTranslation();
-  const { server, expiryDays, activities, gpuOptions, envOptions, groupOptions, error } = useDecsUserData();
+  const { server, servers, expiryDays, activities, gpuOptions, envOptions, groupOptions, error } = useDecsUserData();
   const [submitError, setSubmitError] = React.useState(null);
   const userName = user?.name || user?.email || "사용자";
   const isAdmin = user?.role === "ADMIN";
@@ -44,7 +44,6 @@ function UserPortalApp() {
   const utilities = [
     ...(isAdmin ? [{ type: "custom", content: <RoleSwitch current="user" /> }] : []),
     { text: t("common.language"), onClick: () => i18n.changeLanguage(i18n.language === "en" ? "ko" : "en") },
-    { iconName: "bell", ariaLabel: t("common.notifications"), badge: 1 },
     {
       type: "menu",
       iconName: "user-circle",
@@ -69,16 +68,16 @@ function UserPortalApp() {
     }
   }
 
-  async function submitExtension({ expiresAt, reason }) {
-    if (!server?.requestId) throw new Error("변경할 신청 정보를 찾을 수 없어요.");
+  async function submitExtension({ requestId, expiresAt, reason }) {
+    if (!requestId) throw new Error("변경할 신청 정보를 찾을 수 없어요.");
     const changes = await requestService.getMyChangeRequests();
     const alreadyPending = (changes.data?.data ?? []).some(
-      (change) => change.originalRequestId === server.requestId
+      (change) => change.originalRequestId === requestId
         && change.changeType === "EXPIRES_AT"
         && change.status === "PENDING"
     );
     if (alreadyPending) throw new Error("이미 검토 중인 기간 연장 요청이 있어요.");
-    await requestService.createChangeRequest(server.requestId, {
+    await requestService.createChangeRequest(requestId, {
       changeType: "EXPIRES_AT",
       newValue: expiresAt,
       reason,
@@ -99,7 +98,7 @@ function UserPortalApp() {
         <Routes>
           <Route index element={<UserDashboard userName={userName} server={server} expiryDays={expiryDays} activities={activities ?? []} onRequest={() => navigate("/user/request")} onConnect={() => navigate("/user/container")} onExtend={() => navigate("/user/container")} onDetail={() => navigate("/user/container")} />} />
           <Route path="request" element={<RequestWizard onCancel={() => navigate("/user")} onDone={() => navigate("/user/requests")} gpuOptions={gpuOptions ?? []} envOptions={envOptions ?? []} groupOptions={groupOptions ?? []} onSubmit={submitRequest} />} />
-          <Route path="container" element={<UserContainerDetail onBack={() => navigate("/user")} onExtend={submitExtension} server={server} />} />
+          <Route path="container" element={<UserContainerDetail onBack={() => navigate("/user")} onExtend={submitExtension} servers={servers ?? []} />} />
           <Route path="requests" element={<RequestStatusPage />} />
           <Route path="change-requests" element={<MyChangeRequestsPage />} />
           <Route path="account" element={<AccountPage user={user} />} />

--- a/src/utils/decsMapper.js
+++ b/src/utils/decsMapper.js
@@ -53,8 +53,10 @@ function formatDate(dateStr) {
 }
 
 function getPodExternalPorts(dto) {
-  const ports = dto.portMappings ?? dto.port_mappings ?? dto.podExternalPorts ?? dto.pod_external_ports;
-  return Array.isArray(ports) ? ports : [];
+  // BE가 legacy portMappings를 빈 배열로 함께 내려서, 비어있지 않은 첫 배열을 골라야 한다
+  const ports = [dto.portMappings, dto.port_mappings, dto.podExternalPorts, dto.pod_external_ports]
+    .find((candidate) => Array.isArray(candidate) && candidate.length > 0);
+  return ports ?? [];
 }
 
 function getExternalPort(port) {


### PR DESCRIPTION
## 요약

7/14 `/user/container` QA에서 발견된 P0/P1과 backlog의 FE 갭 3건을 수정합니다.

### 1. 접속 명령·Jupyter 주소가 "—"로 표시되던 버그 (P0)
- `decsMapper.js` `getPodExternalPorts`의 `??` 체인이 BE가 함께 내려주는 `portMappings: []`(빈 배열, null 아님)에서 단락되어 실데이터 `pod_external_ports`를 읽지 못했음.
- 비어있지 않은 첫 배열을 선택하도록 수정 → 이메일로 발송되던 SSH 명령/Jupyter 주소가 프론트에도 표시됨.

### 2. 승인 컨테이너 2건 이상 시 목록 표시 (P1)
- 기존 `useDecsUserData`가 `servers[0]`만 렌더 → 두 번째 이후 컨테이너는 화면에 안 보였음.
- 승인 목록 전체를 만료 임박 순으로 매핑, 2건 이상이면 "내 컨테이너 목록"에서 선택 → 아래 접속 정보 전환.
- 연장 요청은 선택된 컨테이너의 requestId로 제출.

### 3. 대시보드 연장 버튼 → 연장 모달 직결 (backlog FE 갭)
- BigStatus·만료 경고 Alert의 연장 버튼이 화면 이동만 하던 것을 `location.state.extend`로 모달 자동 오픈까지 연결.
- 모달 오픈 시 history.state 제거로 새로고침 재오픈 방지.

### 4. 상단 알림 종 badge 하드코딩 제거
- admin=3, user=1 상수 badge 삭제 (notifications API 도입 전까지).
- "토큰은 대시보드 알림에서 확인" 문구도 승인 메일 안내로 변경.

## 검증 (Playwright, 로컬 preview + 운영 API 실계정)

- 목록 2건 렌더, 각 컨테이너 실제 SSH 명령 표시(ssh testdongmin@…-p 30019 / testdongmin0713@…-p 30021), 선택 전환 동작.
- 대시보드 BigStatus·Alert 연장 버튼 → 모달 자동 오픈(+14일 제안 날짜), 직접 URL 진입 시 미오픈, 새로고침 재오픈 없음.
- 종 아이콘 admin/user 모두 0개, JS 페이지 에러 0건, 빌드·lint 통과(에러 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)