### PR TITLE
fix: EXPIRES_AT 변경요청 승인 차단 해제 (admin_be #368 후속)

### DIFF
--- a/src/pages/admin/ChangeRequestManagementPage.jsx
+++ b/src/pages/admin/ChangeRequestManagementPage.jsx
@@ -23,7 +23,6 @@ const APPROVAL_BLOCK_REASON = {
   GROUP: "DB 그룹만 변경되고 Ubuntu 계정 그룹에는 반영되지 않습니다.",
   RESOURCE_GROUP: "DB 리소스 그룹만 변경되고 실행 중인 Pod에는 반영되지 않습니다.",
   CONTAINER_IMAGE: "DB 이미지 정보만 변경되고 실행 중인 Pod 이미지는 변경되지 않습니다.",
-  EXPIRES_AT: "백엔드의 만료일 생성 형식과 승인 파싱 형식이 서로 다릅니다.",
   PORT: "백엔드 승인 서비스가 포트 변경을 아직 처리하지 않습니다.",
 };
 


### PR DESCRIPTION
admin_be CSID-DGU/admin_be#368 배포로 EXPIRES_AT 변경요청의 생성(JSON 인코딩 저장)-승인(readValue 파싱) 계약이 정합해졌으므로, `APPROVAL_BLOCK_REASON`에서 EXPIRES_AT 차단을 제거합니다.

## 검증 (운영 API, 실주행)

- 사용자 연장 제출 → PENDING 변경요청 생성 정상 (BE #368 배포 후, cr#2).
- 본 수정 빌드(로컬 preview)에서 관리자 승인 실행 → **cr#2 FULFILLED, 원 신청(rid 24) 만료일 2026-07-14 → 2026-07-15 실제 갱신 확인.**
- GROUP/RESOURCE_GROUP/CONTAINER_IMAGE/PORT 차단은 유지 (백엔드 인프라 반영 미구현 — decs-code-spec-260714.md §6 참조).

🤖 Generated with [Claude Code](https://claude.com/claude-code)