### PR TITLE
feat: 접속 안내를 공인 IP 오프셋 포트로 표시 (FARM pfSense 9300 대역)

### DIFF
--- a/src/pages/RequestStatusPage.jsx
+++ b/src/pages/RequestStatusPage.jsx
@@ -14,6 +14,7 @@ import {
 import { useAuth } from "../hooks/useAuth";
 import { requestService } from "../services/requestService";
 import { mapRequestDtoToUiModel } from "../utils/requestMapper";
+import { PUBLIC_HOST, toPublicPort } from "../utils/publicEndpoint";
 
 const RequestStatusPage = () => {
   const [requests, setRequests] = useState([]);
@@ -463,6 +464,14 @@ const RequestStatusPage = () => {
                     const otherPorts = ports.filter(
                       (p) => p.internalPort !== 22 && p.internalPort !== 8888
                     );
+                    const sshPublicPort = sshPort && toPublicPort(sshPort.externalPort);
+                    const jupyterPublicPort = jupyterPort && toPublicPort(jupyterPort.externalPort);
+                    const sshText = sshPublicPort
+                      ? `ssh ${selectedRequest.ubuntu_username}@${PUBLIC_HOST} -p ${sshPublicPort}`
+                      : sshPort && `ssh ${selectedRequest.ubuntu_username}@<서버IP> -p ${sshPort.externalPort}`;
+                    const jupyterText = jupyterPublicPort
+                      ? `http://${PUBLIC_HOST}:${jupyterPublicPort}`
+                      : jupyterPort && `http://<서버IP>:${jupyterPort.externalPort}`;
                     return (
                       <KeyValuePairs
                         columns={1}
@@ -471,9 +480,9 @@ const RequestStatusPage = () => {
                             ? [
                                 {
                                   label: "SSH 접속",
-                                  value: `ssh ${selectedRequest.ubuntu_username}@<서버IP> -p ${sshPort.externalPort}`,
+                                  value: sshText,
                                   copyable: true,
-                                  copyText: `ssh ${selectedRequest.ubuntu_username}@<서버IP> -p ${sshPort.externalPort}`,
+                                  copyText: sshText,
                                 },
                               ]
                             : []),
@@ -481,18 +490,23 @@ const RequestStatusPage = () => {
                             ? [
                                 {
                                   label: "Jupyter 접속",
-                                  value: `http://<서버IP>:${jupyterPort.externalPort}`,
+                                  value: jupyterText,
                                   copyable: true,
-                                  copyText: `http://<서버IP>:${jupyterPort.externalPort}`,
+                                  copyText: jupyterText,
                                 },
                               ]
                             : []),
-                          ...otherPorts.map((port) => ({
-                            label: `추가 포트${
-                              port.usagePurpose ? ` (${port.usagePurpose})` : ""
-                            }`,
-                            value: `${port.externalPort} → ${port.internalPort}`,
-                          })),
+                          ...otherPorts.map((port) => {
+                            const publicPort = toPublicPort(port.externalPort);
+                            return {
+                              label: `추가 포트${
+                                port.usagePurpose ? ` (${port.usagePurpose})` : ""
+                              }`,
+                              value: publicPort
+                                ? `${PUBLIC_HOST}:${publicPort} → ${port.internalPort}`
+                                : `${port.externalPort} → ${port.internalPort}`,
+                            };
+                          }),
                         ]}
                       />
                     );

--- a/src/utils/decsMapper.js
+++ b/src/utils/decsMapper.js
@@ -1,4 +1,5 @@
 import i18n from "../i18n";
+import { PUBLIC_HOST, toPublicPort } from "./publicEndpoint";
 
 const STATUS_MAP = {
   Running: { type: "success", key: "running" },
@@ -142,10 +143,18 @@ export function mapUserServer(dto) {
   const host = getApiHost();
   const sshPort = getExternalPort(findPort(ports, "ssh", 22));
   const jupyterPort = getExternalPort(findPort(ports, "jupyter", 8888));
+  const sshPublicPort = toPublicPort(sshPort);
+  const jupyterPublicPort = toPublicPort(jupyterPort);
   const sshCommand = sshPort && dto.ubuntuUsername
-    ? `ssh ${dto.ubuntuUsername}@${host} -p ${sshPort}`
+    ? sshPublicPort
+      ? `ssh ${dto.ubuntuUsername}@${PUBLIC_HOST} -p ${sshPublicPort}`
+      : `ssh ${dto.ubuntuUsername}@${host} -p ${sshPort}`
     : "—";
-  const jupyterUrl = jupyterPort ? `${getApiProtocol()}//${host}:${jupyterPort}` : "—";
+  const jupyterUrl = jupyterPort
+    ? jupyterPublicPort
+      ? `http://${PUBLIC_HOST}:${jupyterPublicPort}`
+      : `${getApiProtocol()}//${host}:${jupyterPort}`
+    : "—";
 
   return {
     id: dto.requestId,

--- a/src/utils/publicEndpoint.js
+++ b/src/utils/publicEndpoint.js
@@ -1,0 +1,12 @@
+// pfSense FARM 공인 IP 오프셋 매핑(26-07-15): 210.94.179.19:9300-9397 → farm6:30000-30097(NodePort)을 사용자 안내용 외부 주소로 변환
+export const PUBLIC_HOST = "210.94.179.19";
+
+const NODEPORT_BASE = 30000;
+const PUBLIC_PORT_BASE = 9300;
+const BAND_SIZE = 98; // 외부 9300-9397
+
+// NodePort를 외부 공개 포트로 변환한다. 매핑 대역 밖이면 null(외부 접속 불가 — 기존 표기로 폴백).
+export function toPublicPort(nodePort) {
+  const offset = Number(nodePort) - NODEPORT_BASE;
+  return offset >= 0 && offset < BAND_SIZE ? PUBLIC_PORT_BASE + offset : null;
+}


### PR DESCRIPTION
## 배경
FARM pfSense가 죽은 farm4 DNAT 규칙을 재용도해 `210.94.179.19:9300-9397 → farm6(192.168.2.16):30000-30097` 오프셋 포워딩을 적용했다(26-07-15, 외부 테더링에서 SSH 핸드셰이크까지 실측 검증). 기존 FE는 NodePort 번호와 `<서버IP>` 플레이스홀더를 그대로 안내해 사용자가 접속할 수 없는 정보를 받았다.

## 변경
- `src/utils/publicEndpoint.js` 신규 — `외부포트 = 9300 + (NodePort − 30000)` 변환 유틸(대역 밖이면 null)
- `decsMapper.mapUserServer()` — 내 서버의 SSH 명령/Jupyter URL을 `210.94.179.19:93xx`로 표시
- `RequestStatusPage` — `<서버IP>` 플레이스홀더 제거, SSH/Jupyter/추가 포트 전부 변환 표시(복사 텍스트 포함)
- 매핑 대역(30000-30097) 밖 NodePort는 기존 표기로 폴백 — 외부 미개방 포트에 거짓 주소를 만들지 않기 위함

## 검증
- vite build 통과, eslint 클린
- 경로 실측: 외부에서 `210.94.179.19:9314 → farm6:30014`(farm2의 Pod SSH) 접속 성공
- 짝: admin_be `feat/farm-public-port-mail` 브랜치가 배정 메일에 동일 공식 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)