### PR TITLE
fix: SSH/Jupyter 접속 주소 폴백이 localhost를 가리키던 문제 수정

### DIFF
--- a/src/utils/decsMapper.js
+++ b/src/utils/decsMapper.js
@@ -26,24 +26,6 @@ const STATUS_MAP = {
   DENIED: { type: "error", key: "denied" },
 };
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:8080";
-
-function getApiHost() {
-  try {
-    return new URL(API_BASE_URL).hostname;
-  } catch {
-    return "localhost";
-  }
-}
-
-function getApiProtocol() {
-  try {
-    return new URL(API_BASE_URL).protocol;
-  } catch {
-    return "http:";
-  }
-}
-
 function formatDate(dateStr) {
   if (!dateStr) return "—";
 
@@ -140,20 +122,15 @@ export function mapUserServer(dto) {
   const status = mapPodStatus(dto.status);
   const resourceGroup = dto.resourceGroup ?? {};
   const ports = getPodExternalPorts(dto);
-  const host = getApiHost();
   const sshPort = getExternalPort(findPort(ports, "ssh", 22));
   const jupyterPort = getExternalPort(findPort(ports, "jupyter", 8888));
   const sshPublicPort = toPublicPort(sshPort);
   const jupyterPublicPort = toPublicPort(jupyterPort);
   const sshCommand = sshPort && dto.ubuntuUsername
-    ? sshPublicPort
-      ? `ssh ${dto.ubuntuUsername}@${PUBLIC_HOST} -p ${sshPublicPort}`
-      : `ssh ${dto.ubuntuUsername}@${host} -p ${sshPort}`
+    ? `ssh ${dto.ubuntuUsername}@${PUBLIC_HOST} -p ${sshPublicPort ?? sshPort}`
     : "—";
   const jupyterUrl = jupyterPort
-    ? jupyterPublicPort
-      ? `http://${PUBLIC_HOST}:${jupyterPublicPort}`
-      : `${getApiProtocol()}//${host}:${jupyterPort}`
+    ? `http://${PUBLIC_HOST}:${jupyterPublicPort ?? jupyterPort}`
     : "—";
 
   return {


### PR DESCRIPTION
## 요약
- NodePort가 공인 포트 매핑 대역(30000-30097) 밖일 때, SSH/Jupyter 접속 주소를 `getApiHost()`(=`VITE_API_BASE_URL` 파싱값)로 폴백하던 로직이 있었음
- `VITE_API_BASE_URL`을 same-origin 상대경로로 비운 뒤로 이 폴백이 항상 `localhost`로 떨어져, 사용자에게 `ssh user@localhost -p ...`처럼 의미없는 주소가 노출됨
- 이미 이 파일에 정의되어 있던 공인 접속 주소 `PUBLIC_HOST`(publicEndpoint.js)로 통일. `getApiHost()`/`getApiProtocol()`/`API_BASE_URL`은 다른 용도가 없어 함께 제거

## 참고
admin_fe에는 자동화된 테스트 러너가 구성되어 있지 않아 별도 테스트는 추가하지 못했고, eslint만 통과 확인했습니다.

Closes #43