### PR TITLE
[Urgent] fix: nginx가 클러스터 내부 서비스 DNS로 프록시하도록 수정 (로그인 504 해결)

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -5,7 +5,7 @@ server {
     index index.html;
 
     location /api/ {
-        proxy_pass http://210.94.179.18:30083;
+        proxy_pass http://admin-prod.default.svc.cluster.local;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -14,7 +14,7 @@ server {
     }
 
     location /pod-status/ {
-        proxy_pass http://210.94.179.18:30082/;
+        proxy_pass http://containerssh-config-service.ailab-infra.svc.cluster.local/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## 요약
- 프로덕션 로그인을 포함한 모든 `/api/*` 요청이 504로 실패 중이던 문제의 원인과 수정
- `nginx.conf`가 외부 공인 IP(`210.94.179.18:30083`, `:30082`)로 프록시하고 있어서, 클러스터 내부 파드가 자기 클러스터 공인 IP로 나갔다가 NAT hairpin으로 되돌아와야 했음 — 이 경로가 현재 라우터에서 타임아웃 남 (실측 확인됨)
- 내부 서비스 DNS(`admin-prod.default.svc.cluster.local`, `containerssh-config-service.ailab-infra.svc.cluster.local`)로 직접 프록시하도록 변경해 hairpin 경로 자체를 제거

## 긴급도
현재 프로덕션 로그인이 막혀있는 상태입니다. 리뷰 후 최대한 빠르게 머지/재배포 부탁드립니다.

Closes #45