### PR TITLE
feat: 관리자 콘솔에 Pod GPU 노드 마이그레이션 UI 추가

### DIFF
--- a/src/pages/admin/RequestManagementPage.jsx
+++ b/src/pages/admin/RequestManagementPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   Container,
   Header,
@@ -11,6 +11,7 @@ import {
   StatusIndicator,
   Badge,
   KeyValuePairs,
+  Input,
 } from "../../design-system";
 import { requestService } from "../../services/requestService";
 import { mapRequestDtoToUiModel } from "../../utils/requestMapper";
@@ -36,43 +37,49 @@ const RequestManagementPage = () => {
   const [filter, setFilter] = useState("ALL"); // ALL, PENDING, FULFILLED, DENIED
   const [alert, setAlert] = useState(null);
   const [processingRequestId, setProcessingRequestId] = useState(null);
+  const [migratingRequestId, setMigratingRequestId] = useState(null);
+  const [migrateTarget, setMigrateTarget] = useState(null);
+  const [migrateNodeOptions, setMigrateNodeOptions] = useState([]);
+  const [selectedMigrateNodes, setSelectedMigrateNodes] = useState(new Set());
+  const [minImprovementRatio, setMinImprovementRatio] = useState("0.2");
+  const [migrateLoadError, setMigrateLoadError] = useState(null);
 
-  useEffect(() => {
-    const fetchRequests = async () => {
-      setIsLoading(true);
-      setAlert(null);
+  const fetchRequests = useCallback(async () => {
+    setIsLoading(true);
+    setAlert(null);
 
-      try {
-        const response = await requestService.getAllRequests();
+    try {
+      const response = await requestService.getAllRequests();
 
-        if (response.status === 200) {
-          // API 응답 데이터를 기존 UI에 맞게 변환
-          // response.data는 서버 응답이고, response.data.data가 실제 배열
-          const requestsArray = response.data?.data ?? [];
-          const transformedRequests = requestsArray.map(mapRequestDtoToUiModel);
+      if (response.status === 200) {
+        // API 응답 데이터를 기존 UI에 맞게 변환
+        // response.data는 서버 응답이고, response.data.data가 실제 배열
+        const requestsArray = response.data?.data ?? [];
+        const transformedRequests = requestsArray.map(mapRequestDtoToUiModel);
 
-          setRequests(transformedRequests);
-        } else {
-          setAlert({
-            type: "error",
-            message:
-              "신청서 목록을 불러올 수 없습니다. 서버 상태를 확인하시거나 관리자에게 문의해주세요.",
-          });
-        }
-      } catch (error) {
-        console.error("Failed to fetch requests:", error);
+        setRequests(transformedRequests);
+      } else {
         setAlert({
           type: "error",
           message:
-            "신청서 목록 로딩 중 네트워크 오류가 발생했습니다. 인터넷 연결을 확인하시고 페이지를 새로고침해주세요.",
+            "신청서 목록을 불러올 수 없습니다. 서버 상태를 확인하시거나 관리자에게 문의해주세요.",
         });
-      } finally {
-        setIsLoading(false);
       }
-    };
-
-    fetchRequests();
+    } catch (error) {
+      console.error("Failed to fetch requests:", error);
+      setAlert({
+        type: "error",
+        message:
+          "신청서 목록 로딩 중 네트워크 오류가 발생했습니다. 인터넷 연결을 확인하시고 페이지를 새로고침해주세요.",
+      });
+    } finally {
+      setIsLoading(false);
+    }
   }, []);
+
+  useEffect(() => {
+    fetchRequests();
+  }, [fetchRequests]);
 
   const filteredRequests = requests
     .filter((request) => {
@@ -184,6 +191,114 @@ const RequestManagementPage = () => {
     }
   };
 
+  const MIGRATE_SKIP_REASON_LABELS = {
+    no_significant_improvement: "이미 최적 노드에 있어 마이그레이션이 필요하지 않습니다.",
+    no_candidate_node: "이동 가능한 다른 노드가 없습니다.",
+  };
+
+  const openMigrateModal = async (request) => {
+    if (migratingRequestId !== null) return;
+    setMigrateLoadError(null);
+    setMigrateTarget(request);
+    setMigrateNodeOptions([]);
+    setSelectedMigrateNodes(new Set());
+    setMinImprovementRatio("0.2");
+
+    try {
+      const response = await requestService.getGpuTypes();
+      const gpuTypes = response.data?.data ?? [];
+      const nodeIds = [
+        ...new Set(
+          gpuTypes
+            .filter((g) => String(g.rsgroupId) === String(request.rsgroup_id))
+            .map((g) => g.nodeId)
+            .filter(Boolean)
+        ),
+      ];
+      setMigrateNodeOptions(nodeIds);
+      // 현재 노드가 후보 목록에 반드시 포함되어야 하므로 기본적으로 전부 선택해둔다.
+      setSelectedMigrateNodes(new Set(nodeIds));
+      if (nodeIds.length === 0) {
+        setMigrateLoadError("이 리소스 그룹에 속한 노드 정보를 찾을 수 없습니다.");
+      }
+    } catch (error) {
+      console.error("Failed to load node options for migration:", error);
+      setMigrateLoadError("노드 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.");
+    }
+  };
+
+  const closeMigrateModal = () => {
+    if (migratingRequestId !== null) return;
+    setMigrateTarget(null);
+  };
+
+  const toggleMigrateNode = (nodeId) => {
+    setSelectedMigrateNodes((prev) => {
+      const next = new Set(prev);
+      if (next.has(nodeId)) next.delete(nodeId);
+      else next.add(nodeId);
+      return next;
+    });
+  };
+
+  const handleMigrate = async () => {
+    const request = migrateTarget;
+    if (!request || selectedMigrateNodes.size === 0) return;
+
+    setMigratingRequestId(request.request_id);
+    try {
+      const ratio = parseFloat(minImprovementRatio);
+      const response = await requestService.migrateRequest(request.request_id, {
+        nodes: [...selectedMigrateNodes],
+        ...(Number.isFinite(ratio) ? { minImprovementRatio: ratio } : {}),
+      });
+
+      const result = response.data?.data;
+
+      if (response.status === 200 && result?.status === "migrated") {
+        setAlert({
+          type: "success",
+          message: `${request.user_name}님의 서버를 ${result.from} → ${result.to} 노드로 마이그레이션했습니다.`,
+        });
+        setMigrateTarget(null);
+        await fetchRequests();
+      } else if (response.status === 200 && result?.status === "skipped") {
+        setAlert({
+          type: "info",
+          message:
+            MIGRATE_SKIP_REASON_LABELS[result.reason] ||
+            `마이그레이션이 건너뛰어졌습니다. (${result.reason || "알 수 없는 사유"})`,
+        });
+        setMigrateTarget(null);
+      } else {
+        setAlert({
+          type: "error",
+          message: "마이그레이션 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+        });
+      }
+    } catch (error) {
+      console.error("Failed to migrate pod:", error);
+
+      if (error.name === "TimeoutError" || error.name === "AbortError") {
+        setAlert({
+          type: "warning",
+          message: "마이그레이션 응답 시간이 초과되었습니다. 재시도하기 전에 목록을 새로고침해 실제 상태를 확인해주세요.",
+        });
+        setMigrateTarget(null);
+        await fetchRequests();
+      } else {
+        setAlert({
+          type: "error",
+          message: error.status
+            ? `마이그레이션에 실패했습니다. ${error.message}`
+            : "서버와 연결할 수 없습니다. 네트워크를 확인하고 잠시 후 다시 시도해주세요.",
+        });
+      }
+    } finally {
+      setMigratingRequestId(null);
+    }
+  };
+
   const promptApprove = (request) => {
     const comment = prompt("승인 사유를 입력하세요:", "승인되었습니다.");
     if (comment !== null) {
@@ -283,6 +398,16 @@ const RequestManagementPage = () => {
               onClick={() => promptDeny(r)}
             >
               거절
+            </Button>
+          )}
+          {r.status === "FULFILLED" && (
+            <Button
+              variant="inline-link"
+              disabled={migratingRequestId !== null}
+              loading={migratingRequestId === r.request_id}
+              onClick={() => openMigrateModal(r)}
+            >
+              마이그레이션
             </Button>
           )}
         </div>
@@ -542,6 +667,69 @@ const RequestManagementPage = () => {
                   </Alert>
                 </div>
               )}
+            </div>
+          </div>
+        </Modal>
+      )}
+
+      {/* 마이그레이션 모달 */}
+      {migrateTarget && (
+        <Modal
+          visible
+          onDismiss={closeMigrateModal}
+          header={`Pod 마이그레이션 — ${migrateTarget.user_name}`}
+          footer={
+            <>
+              <Button variant="normal" disabled={migratingRequestId !== null} onClick={closeMigrateModal}>
+                취소
+              </Button>
+              <Button
+                variant="primary"
+                disabled={migratingRequestId !== null || selectedMigrateNodes.size === 0}
+                loading={migratingRequestId === migrateTarget.request_id}
+                onClick={handleMigrate}
+              >
+                마이그레이션 실행
+              </Button>
+            </>
+          }
+        >
+          <div className="space-y-4">
+            <Alert type="warning">
+              실행 중인 서버를 다른 GPU 노드로 이동합니다. 이동 도중 일시적으로 접속이 끊길 수 있고, 완료까지 몇 분 걸릴 수 있습니다.
+            </Alert>
+
+            {migrateLoadError && <Alert type="error">{migrateLoadError}</Alert>}
+
+            <div>
+              <div className="text-(--decs-text-inactive) mb-2">
+                후보 노드 (현재 노드를 포함해야 하므로 임의로 해제하지 마세요)
+              </div>
+              <div className="space-y-1">
+                {migrateNodeOptions.map((nodeId) => (
+                  <label key={nodeId} className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={selectedMigrateNodes.has(nodeId)}
+                      onChange={() => toggleMigrateNode(nodeId)}
+                    />
+                    <span>{nodeId}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <div className="text-(--decs-text-inactive) mb-1">최소 개선 비율</div>
+              <Input
+                type="number"
+                value={minImprovementRatio}
+                onChange={setMinImprovementRatio}
+                placeholder="0.2"
+              />
+              <div className="text-(--decs-text-secondary)" style={{ fontSize: "var(--decs-fs-body-s)", marginTop: 4 }}>
+                후보 노드 중 가장 여유있는 노드가 현재 노드보다 이 비율 이상 나아야 마이그레이션이 실행됩니다.
+              </div>
             </div>
           </div>
         </Modal>

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -119,8 +119,9 @@ class ApiClient {
     });
   }
 
-  async post(endpoint, data = {}) {
+  async post(endpoint, data = {}, options = {}) {
     return this.request(endpoint, {
+      ...options,
       method: "POST",
       body: JSON.stringify(data),
     });

--- a/src/services/requestService.js
+++ b/src/services/requestService.js
@@ -15,6 +15,12 @@ export const requestService = {
     }),
   rejectRequest: (data) => apiClient.patch("/api/admin/requests/reject", data),
 
+  migrateRequest: (requestId, data) =>
+    apiClient.post(`/api/admin/requests/${requestId}/migrate`, data, {
+      // 새 Pod 생성·기동 대기까지 동기 처리되어 승인과 동일하게 여유를 둡니다.
+      signal: AbortSignal.timeout(310_000),
+    }),
+
   createChangeRequest: (requestId, data) =>
     apiClient.post(`/api/requests/${requestId}/change`, data),
   getChangeRequests: () => apiClient.get("/api/admin/requests/change/all"),


### PR DESCRIPTION
## 요약
- `AdminRequestController`에 새로 추가된 `POST /api/admin/requests/{requestId}/migrate`를 트리거하는 관리자 UI를 신청서 관리 화면(`RequestManagementPage`)에 추가
- FULFILLED 상태 행에 "마이그레이션" 액션 추가 → 모달에서 후보 노드(같은 리소스 그룹 소속, gpu-types API로 조회) 체크박스 선택 + 최소 개선 비율 입력 → 실행
- 결과 처리: migrated(성공, from→to 안내 후 목록 새로고침) / skipped(사유 안내) / 에러(409/타임아웃/일반 오류 각각 다른 메시지, 기존 승인 플로우와 동일한 패턴)
- `apiClient.post`가 `patch`/`put`처럼 fetch 옵션을 받을 수 있도록 확장 (타임아웃 지정 위해 필요)

## 판단 근거 (요청받은 초안과 다르게 간 부분)
- 원래는 "컨테이너 관리"(`ContainerManagement`/`ContainerDetail`) 화면에 붙이는 걸 검토했으나, 그 화면이 쓰는 `ContainerInfoDTO`에 `requestId`가 아예 없어서 API 호출이 불가능했습니다. `requestId`를 가진 "신청서 관리" 화면에 붙였습니다.
- 노드 선택 UI는 디자인시스템에 멀티셀렉트/체크박스 컴포넌트가 없어서 순수 HTML checkbox + 기존 유틸리티 클래스로 구현했습니다.
- 테스트 프레임워크가 이 레포에 없어(vitest/jest 미설정) eslint(0 error) + 수동 코드 리뷰로 검증했습니다.

## 전제
`POST /api/admin/requests/{requestId}/migrate`가 admin_be `develop`에 머지되어 있어야 동작합니다 (PR #398).

Closes #47