### PR TITLE
fix: Ubuntu 비밀번호 base64 인코딩 프론트 측 제거

### DIFF
--- a/src/pages/decs-console/user/UserPortalApp.jsx
+++ b/src/pages/decs-console/user/UserPortalApp.jsx
@@ -125,7 +125,7 @@ function toRequestPayload(form) {
     resourceGroupId: parseInt(form.gpu, 10),
     imageId: parseInt(form.env, 10),
     ubuntuUsername: form.ubuntuUsername,
-    ubuntuPassword: bytesToBase64(new TextEncoder().encode(form.ubuntuPassword)),
+    ubuntuPassword: form.ubuntuPassword,
     // 30083 신청 DTO의 레거시 필수 필드. PVC UI에서는 노출하지 않는다.
     volumeSizeGiB: 20,
     usagePurpose: form.usagePurpose,
@@ -134,12 +134,6 @@ function toRequestPayload(form) {
     ubuntuGids: (form.ubuntuGids ?? []).map((gid) => parseInt(gid, 10)),
     portRequests: form.portRequests ?? [],
   };
-}
-
-function bytesToBase64(bytes) {
-  let binary = "";
-  bytes.forEach((byte) => { binary += String.fromCharCode(byte); });
-  return window.btoa(binary);
 }
 
 export default UserPortalApp;


### PR DESCRIPTION
## 요약
- 서버 신청 폼에서 비밀번호를 base64로 인코딩해 전송하던 로직 제거, 평문으로 전송 (HTTPS로 이미 암호화되어 전달됨)
- base64 인코딩은 백엔드가 infra(config-server) 전송 시점에만 계산하도록 정리 — admin_be #409, PR #410 대응 짝

Closes #53