### PR TITLE
feat: 승인 진행 상태 표시 및 대시보드 자동 갱신

### DIFF
--- a/src/hooks/useDecsAdminData.js
+++ b/src/hooks/useDecsAdminData.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { podService } from "../services/podService";
 import userService from "../services/userService";
 import { mapAdminContainer } from "../utils/decsMapper";
@@ -15,68 +15,70 @@ export function useDecsAdminData() {
   const [containers, setContainers] = useState(undefined);
   const [users, setUsers] = useState(undefined);
   const [error, setError] = useState(null);
+  const cancelledRef = useRef(false);
 
-  useEffect(() => {
-    let cancelled = false;
+  const load = useCallback(async () => {
+    setError(null);
 
-    async function load() {
-      const [containersResult, usersResult] = await Promise.allSettled([
-        podService.getActiveContainers(),
-        userService.getAllUsers(),
-      ]);
-      if (cancelled) return;
+    const [containersResult, usersResult] = await Promise.allSettled([
+      podService.getActiveContainers(),
+      userService.getAllUsers(),
+    ]);
+    if (cancelledRef.current) return;
 
-      let hasError = false;
+    let hasError = false;
 
-      if (containersResult.status === "fulfilled" && containersResult.value?.status === 200) {
-        const activeContainers = getArrayData(containersResult.value);
-        if (activeContainers) {
-          const [details, provisioningStatuses] = await Promise.all([
-            Promise.allSettled(activeContainers.map((container) =>
-              container.podName ? podService.getPod(container.podName) : Promise.resolve(null)
-            )),
-            Promise.allSettled(activeContainers.map((container) =>
-              container.ubuntuUsername ? podService.getProvisioningStatus(container.ubuntuUsername) : Promise.resolve(null)
-            )),
-          ]);
-          if (cancelled) return;
-          setContainers(activeContainers.map((container, index) => {
-            const result = details[index];
-            const statusResult = provisioningStatuses[index];
-            const detail = result.status === "fulfilled" ? result.value?.data?.data ?? result.value?.data : null;
-            const provisioning = statusResult.status === "fulfilled" ? statusResult.value?.data : null;
-            if (container.podName && !detail && (!provisioning || provisioning.stage === "unknown")) hasError = true;
-            return mapAdminContainer({ ...container, podDetail: detail, status: detail?.status ?? provisioning?.stage });
-          }));
-        } else {
-          hasError = true;
-        }
+    if (containersResult.status === "fulfilled" && containersResult.value?.status === 200) {
+      const activeContainers = getArrayData(containersResult.value);
+      if (activeContainers) {
+        const [details, provisioningStatuses] = await Promise.all([
+          Promise.allSettled(activeContainers.map((container) =>
+            container.podName ? podService.getPod(container.podName) : Promise.resolve(null)
+          )),
+          Promise.allSettled(activeContainers.map((container) =>
+            container.ubuntuUsername ? podService.getProvisioningStatus(container.ubuntuUsername) : Promise.resolve(null)
+          )),
+        ]);
+        if (cancelledRef.current) return;
+        setContainers(activeContainers.map((container, index) => {
+          const result = details[index];
+          const statusResult = provisioningStatuses[index];
+          const detail = result.status === "fulfilled" ? result.value?.data?.data ?? result.value?.data : null;
+          const provisioning = statusResult.status === "fulfilled" ? statusResult.value?.data : null;
+          if (container.podName && !detail && (!provisioning || provisioning.stage === "unknown")) hasError = true;
+          return mapAdminContainer({ ...container, podDetail: detail, status: detail?.status ?? provisioning?.stage });
+        }));
       } else {
         hasError = true;
       }
-
-      if (usersResult.status === "fulfilled" && usersResult.value?.status === 200) {
-        const userList = getArrayData(usersResult.value);
-        if (userList) {
-          setUsers(userList);
-        } else {
-          hasError = true;
-        }
-      } else {
-        hasError = true;
-      }
-
-      if (hasError) {
-        setError(ERROR_MESSAGE);
-      }
+    } else {
+      hasError = true;
     }
 
+    if (usersResult.status === "fulfilled" && usersResult.value?.status === 200) {
+      const userList = getArrayData(usersResult.value);
+      if (userList) {
+        setUsers(userList);
+      } else {
+        hasError = true;
+      }
+    } else {
+      hasError = true;
+    }
+
+    if (hasError) {
+      setError(ERROR_MESSAGE);
+    }
+  }, []);
+
+  useEffect(() => {
+    cancelledRef.current = false;
     load();
 
     return () => {
-      cancelled = true;
+      cancelledRef.current = true;
     };
-  }, []);
+  }, [load]);
 
-  return { containers, users, error };
+  return { containers, users, error, refetch: load };
 }

--- a/src/pages/admin/RequestManagementPage.jsx
+++ b/src/pages/admin/RequestManagementPage.jsx
@@ -13,6 +13,7 @@ import {
   KeyValuePairs,
 } from "../../design-system";
 import { requestService } from "../../services/requestService";
+import { podService } from "../../services/podService";
 import { mapRequestDtoToUiModel } from "../../utils/requestMapper";
 
 const STATUS_META = {
@@ -36,6 +37,32 @@ const RequestManagementPage = () => {
   const [filter, setFilter] = useState("ALL"); // ALL, PENDING, FULFILLED, DENIED
   const [alert, setAlert] = useState(null);
   const [processingRequestId, setProcessingRequestId] = useState(null);
+  const [processingUsername, setProcessingUsername] = useState(null);
+  const [provisioningStatus, setProvisioningStatus] = useState(null);
+
+  // 승인 처리 중(Pod 생성 포함)일 때 config-server의 세세한 진행 단계를 폴링해서 보여준다.
+  // 조회 실패는 승인 흐름 자체에 영향을 주지 않으므로 조용히 무시한다.
+  useEffect(() => {
+    if (!processingUsername) {
+      setProvisioningStatus(null);
+      return;
+    }
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const res = await podService.getProvisioningStatus(processingUsername);
+        if (!cancelled) setProvisioningStatus(res?.data ?? null);
+      } catch {
+        // ignore
+      }
+    };
+    poll();
+    const interval = setInterval(poll, 2000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [processingUsername]);
 
   useEffect(() => {
     const fetchRequests = async () => {
@@ -100,6 +127,7 @@ const RequestManagementPage = () => {
   const handleStatusUpdate = async (request, newStatus, comment = "") => {
     if (processingRequestId !== null) return;
     setProcessingRequestId(request.request_id);
+    if (newStatus === "FULFILLED") setProcessingUsername(request.ubuntu_username);
     try {
       let response;
 
@@ -181,6 +209,7 @@ const RequestManagementPage = () => {
       }
     } finally {
       setProcessingRequestId(null);
+      setProcessingUsername(null);
     }
   };
 
@@ -317,7 +346,12 @@ const RequestManagementPage = () => {
           ]}
         />
       )}
-      {processingRequestId !== null ? <Alert type="info">Pod 생성으로 승인 처리에 최대 5분이 걸릴 수 있습니다. 완료될 때까지 창을 닫거나 다시 클릭하지 마세요.</Alert> : null}
+      {processingRequestId !== null ? (
+        <Alert type="info">
+          Pod 생성으로 승인 처리에 최대 5분이 걸릴 수 있습니다. 완료될 때까지 창을 닫거나 다시 클릭하지 마세요.
+          {provisioningStatus?.message ? ` (현재 단계: ${provisioningStatus.message})` : null}
+        </Alert>
+      ) : null}
 
       <Header
         variant="h1"

--- a/src/pages/decs-console/admin/AdminConsoleApp.jsx
+++ b/src/pages/decs-console/admin/AdminConsoleApp.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Navigate, Route, Routes, useLocation, useNavigate, useParams } from "react-router-dom";
 import { AppLayout, SideNavigation, Flashbar } from "../../../design-system";
 import AdminDashboard from "./AdminDashboard";
@@ -20,7 +20,15 @@ function AdminConsoleApp() {
   const navigate = useNavigate();
   const { user, logout } = useAuth();
   const { t, i18n } = useTranslation();
-  const { containers, users, error } = useDecsAdminData();
+  const { containers, users, error, refetch } = useDecsAdminData();
+
+  // 요청 관리 화면에서 승인/거절 처리 후 대시보드로 돌아왔을 때 최신 상태가 바로 보이도록,
+  // 대시보드 관련 경로에 진입할 때마다 다시 불러온다.
+  useEffect(() => {
+    if (location.pathname === "/admin" || location.pathname.startsWith("/admin/containers")) {
+      refetch();
+    }
+  }, [location.pathname, refetch]);
 
   const nav = {
     header: { text: "DECS Admin", href: "/admin" },


### PR DESCRIPTION
## 요약
- 요청 관리 화면에서 승인 처리 중 config-server의 세세한 Pod 생성 진행 상태(started/selecting_node/.../ready)를 폴링해서 스피너 옆에 표시
- 대시보드가 마운트 시 한 번만 데이터를 불러오던 것을, 대시보드 관련 경로 진입 시마다 자동 재조회하도록 수정 — 다른 화면(요청 관리 등)에서 승인/거절한 결과가 바로 반영됨

Closes #55

## Test plan
- [x] `npm run build` 통과
- [x] `npm run lint` 통과 (기존 경고 3건 외 신규 이슈 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added live provisioning progress updates during request approvals, showing the current configuration step.
  - Admin dashboard and container views now refresh their data when opened or revisited.

- **Bug Fixes**
  - Improved approval-status handling by safely stopping progress updates when requests finish, fail, or the page changes.
  - Added a reliable way to reload administrative data and display the latest containers, users, and errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->