### PR TITLE
fix: 이메일 인증 API 호출을 요청 본문 방식으로 변경

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -126,25 +126,6 @@ class ApiClient {
     });
   }
 
-  // POST 요청에 쿼리 파라미터 사용 (curl과 동일한 방식)
-  async postWithQuery(endpoint, params = {}) {
-    const url = new URL(endpoint, window.location.origin);
-    Object.keys(params).forEach((key) => {
-      if (params[key] !== undefined && params[key] !== null) {
-        url.searchParams.append(key, params[key]);
-      }
-    });
-
-    return this.request(url.pathname + url.search, {
-      method: "POST",
-      headers: {
-        accept: "application/json;charset=UTF-8",
-        // Content-Type은 빈 body일 때 제거
-      },
-      body: "", // 빈 body (curl -d '' 와 동일)
-    });
-  }
-
   async put(endpoint, data = {}) {
     return this.request(endpoint, {
       method: "PUT",

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -24,8 +24,7 @@ export const authService = {
   // 이메일 인증번호 발송
   sendEmailVerification: async (email) => {
     try {
-      // POST 요청으로 이메일을 쿼리 파라미터로 전송 (curl과 동일)
-      const response = await apiClient.postWithQuery("/api/auth/email/send", {
+      const response = await apiClient.post("/api/auth/email/send", {
         email,
       });
       return response;
@@ -38,8 +37,7 @@ export const authService = {
   // 이메일 인증번호 검증
   verifyEmailCode: async (email, code) => {
     try {
-      // POST 요청으로 이메일과 코드를 쿼리 파라미터로 전송 (curl과 동일)
-      const response = await apiClient.postWithQuery("/api/auth/email/verify", {
+      const response = await apiClient.post("/api/auth/email/verify", {
         email,
         code,
       });


### PR DESCRIPTION
## 요약
admin_be PR #415에서 /api/auth/email/send, /api/auth/email/verify가 쿼리 파라미터 대신 JSON 요청 본문을 받도록 바뀜에 따라 프론트 호출부도 postWithQuery 대신 post로 변경. 더 이상 쓰이지 않는 postWithQuery 헬퍼도 함께 제거.

Closes #57

## Test plan
- [x] npm run build 통과
- [x] npm run lint 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated email verification requests to send email addresses and verification codes in the request body.
  * Preserved existing error handling and response behavior for verification flows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->