### PR TITLE
fix: nginx/ingress 프록시 타임아웃을 admin_be 처리 시간에 맞춰 상향

### DIFF
--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -6,6 +6,12 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    # admin_be의 Pod 생성/마이그레이션 동기 처리(최대 600s)가 ingress-nginx 기본
+    # proxy-read-timeout(60s)에 끊기지 않도록 여유 있게 늘린다. (nginx.conf의
+    # 컨테이너 내부 프록시 타임아웃과 반드시 같이 맞춰야 한다.)
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "650"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "650"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "650"
 spec:
   ingressClassName: nginx-ailab
   rules:

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,6 +11,11 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Origin "";
+        # admin_be의 Pod 생성/마이그레이션 동기 처리(최대 600s)가 nginx 기본
+        # proxy_read_timeout(60s)에 끊기지 않도록 여유 있게 늘린다.
+        proxy_connect_timeout 650s;
+        proxy_send_timeout 650s;
+        proxy_read_timeout 650s;
     }
 
     location /pod-status/ {
@@ -18,6 +23,9 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_connect_timeout 650s;
+        proxy_send_timeout 650s;
+        proxy_read_timeout 650s;
     }
 
     location / {


### PR DESCRIPTION
## Summary
- 컨테이너 내부 nginx와 ingress-nginx 컨트롤러 둘 다 기본 `proxy_read_timeout`(60s)을 쓰고 있어, admin_be의 Pod 생성/마이그레이션 동기 처리(최대 600s)가 끝나기 전에 504로 끊기는 문제 수정
- 실제로는 admin_be가 백그라운드에서 계속 처리(보상 트랜잭션 포함)해서 끝까지 완료하는데도, 관리자 화면에는 1분 만에 실패로 표시됨 — nginx/ingress-nginx 양쪽 다 650s로 상향

## Test plan
- [x] `k8s/ingress.yaml` YAML 문법 확인 (python yaml.safe_load)
- [ ] 배포 후 승인/마이그레이션처럼 5분 이상 걸리는 요청이 504 없이 끝까지 응답받는지 확인 필요 (이미지 재빌드 + k8s 재배포 필요)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased request timeouts for API and pod-status operations.
  * Long-running pod creation and migration tasks can now complete without being interrupted by gateway timeouts.
  * Applied consistent timeout handling across ingress and proxy routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->