### PR TITLE
feat: 관리자 신청서 화면에 Pod 마이그레이션 연동 추가

### DIFF
--- a/src/pages/admin/RequestManagementPage.jsx
+++ b/src/pages/admin/RequestManagementPage.jsx
@@ -11,6 +11,8 @@ import {
   StatusIndicator,
   Badge,
   KeyValuePairs,
+  FormField,
+  Input,
 } from "../../design-system";
 import { requestService } from "../../services/requestService";
 import { podService } from "../../services/podService";
@@ -39,6 +41,11 @@ const RequestManagementPage = () => {
   const [processingRequestId, setProcessingRequestId] = useState(null);
   const [processingUsername, setProcessingUsername] = useState(null);
   const [provisioningStatus, setProvisioningStatus] = useState(null);
+  const [migratingRequest, setMigratingRequest] = useState(null);
+  const [migrateNodesInput, setMigrateNodesInput] = useState("");
+  const [migrateRatioInput, setMigrateRatioInput] = useState("");
+  const [migrateFormError, setMigrateFormError] = useState(null);
+  const [isMigrating, setIsMigrating] = useState(false);
 
   // 승인 처리 중(Pod 생성 포함)일 때 config-server의 세세한 진행 단계를 폴링해서 보여준다.
   // 조회 실패는 승인 흐름 자체에 영향을 주지 않으므로 조용히 무시한다.
@@ -227,6 +234,81 @@ const RequestManagementPage = () => {
     }
   };
 
+  const openMigrate = (request) => {
+    setMigratingRequest(request);
+    setMigrateNodesInput("");
+    setMigrateRatioInput("");
+    setMigrateFormError(null);
+  };
+
+  const closeMigrate = () => {
+    if (isMigrating) return;
+    setMigratingRequest(null);
+  };
+
+  const submitMigrate = async () => {
+    const nodes = migrateNodesInput
+      .split(",")
+      .map((n) => n.trim())
+      .filter(Boolean);
+
+    if (nodes.length === 0) {
+      setMigrateFormError("후보 노드를 하나 이상 입력하세요.");
+      return;
+    }
+
+    let minImprovementRatio;
+    if (migrateRatioInput.trim() !== "") {
+      const parsed = Number(migrateRatioInput.trim());
+      if (Number.isNaN(parsed)) {
+        setMigrateFormError("최소 개선 비율은 숫자로 입력하세요.");
+        return;
+      }
+      minImprovementRatio = parsed;
+    }
+
+    setMigrateFormError(null);
+    setIsMigrating(true);
+    try {
+      const response = await requestService.migrateRequest(
+        migratingRequest.request_id,
+        nodes,
+        minImprovementRatio
+      );
+      const result = response.data?.data ?? response.data;
+
+      if (result?.status === "migrated") {
+        setAlert({
+          type: "success",
+          message: `${migratingRequest.user_name}님의 Pod를 ${result.from} → ${result.to}(으)로 마이그레이션했습니다.${
+            result.old_pod_cleanup === "failed" ? " (기존 Pod 정리는 실패해 수동 확인이 필요합니다.)" : ""
+          }`,
+        });
+      } else {
+        setAlert({
+          type: "info",
+          message: `마이그레이션을 건너뛰었습니다: ${result?.reason ?? "개선 효과가 충분하지 않습니다."}${
+            result?.best_candidate ? ` (최적 후보: ${result.best_candidate})` : ""
+          }`,
+        });
+      }
+      setMigratingRequest(null);
+    } catch (error) {
+      console.error("Failed to migrate pod:", error);
+      if (error.status === 409) {
+        setMigrateFormError("이미 마이그레이션이 진행 중이거나 FULFILLED 상태가 아닙니다.");
+      } else if (error.status === 502) {
+        setMigrateFormError("config-server 마이그레이션 API 호출에 실패했습니다.");
+      } else if (error.name === "TimeoutError" || error.name === "AbortError") {
+        setMigrateFormError("응답 시간이 초과되었습니다. 실제 처리 상태는 목록을 새로고침해 확인해주세요.");
+      } else {
+        setMigrateFormError(error.message || "마이그레이션 요청에 실패했습니다.");
+      }
+    } finally {
+      setIsMigrating(false);
+    }
+  };
+
   const formatDate = (dateString) => {
     return new Date(dateString).toLocaleDateString("ko-KR", {
       year: "numeric",
@@ -312,6 +394,11 @@ const RequestManagementPage = () => {
               onClick={() => promptDeny(r)}
             >
               거절
+            </Button>
+          )}
+          {r.status === "FULFILLED" && (
+            <Button variant="inline-link" onClick={() => openMigrate(r)}>
+              마이그레이션
             </Button>
           )}
         </div>
@@ -418,6 +505,11 @@ const RequestManagementPage = () => {
               {sel.status === "PENDING" && (
                 <Button variant="primary" disabled={processingRequestId !== null} loading={processingRequestId === sel.request_id} onClick={() => promptApprove(sel)}>
                   승인
+                </Button>
+              )}
+              {sel.status === "FULFILLED" && (
+                <Button variant="primary" onClick={() => openMigrate(sel)}>
+                  마이그레이션
                 </Button>
               )}
             </>
@@ -577,6 +669,56 @@ const RequestManagementPage = () => {
                 </div>
               )}
             </div>
+          </div>
+        </Modal>
+      )}
+
+      {/* Migrate Modal */}
+      {migratingRequest && (
+        <Modal
+          visible
+          onDismiss={closeMigrate}
+          header={`Pod 마이그레이션 — ${migratingRequest.user_name} (${migratingRequest.ubuntu_username})`}
+          footer={
+            <>
+              <Button variant="normal" disabled={isMigrating} onClick={closeMigrate}>
+                취소
+              </Button>
+              <Button variant="primary" loading={isMigrating} onClick={submitMigrate}>
+                마이그레이션 실행
+              </Button>
+            </>
+          }
+        >
+          <div className="space-y-4">
+            <Alert type="info">
+              config-server가 후보 노드 중 가장 개선 효과가 큰 노드로 Pod를 옮깁니다. 완료까지 최대 10분이 걸릴 수 있습니다.
+            </Alert>
+            <FormField
+              label="후보 노드"
+              description="현재 배포된 노드를 포함해 쉼표(,)로 구분해 입력하세요."
+              constraintText="예: farm1, farm2"
+              errorText={migrateFormError}
+            >
+              <Input
+                value={migrateNodesInput}
+                onChange={setMigrateNodesInput}
+                placeholder="farm1, farm2"
+                disabled={isMigrating}
+              />
+            </FormField>
+            <FormField
+              label="최소 개선 비율 (선택)"
+              description="생략하면 config-server 기본값을 사용합니다."
+            >
+              <Input
+                value={migrateRatioInput}
+                onChange={setMigrateRatioInput}
+                placeholder="0.2"
+                type="number"
+                disabled={isMigrating}
+              />
+            </FormField>
           </div>
         </Modal>
       )}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -119,8 +119,9 @@ class ApiClient {
     });
   }
 
-  async post(endpoint, data = {}) {
+  async post(endpoint, data = {}, options = {}) {
     return this.request(endpoint, {
+      ...options,
       method: "POST",
       body: JSON.stringify(data),
     });

--- a/src/services/requestService.js
+++ b/src/services/requestService.js
@@ -30,6 +30,15 @@ export const requestService = {
     }),
   getMyChangeRequests: () => apiClient.get("/api/requests/my/changes"),
 
+  migrateRequest: (requestId, nodes, minImprovementRatio) =>
+    apiClient.post(`/api/admin/requests/${requestId}/migrate`, {
+      nodes,
+      ...(minImprovementRatio != null && { minImprovementRatio }),
+    }, {
+      // config-server 마이그레이션 API 타임아웃(10분)보다 조금 길게 대기합니다.
+      signal: AbortSignal.timeout(610_000),
+    }),
+
   getGpuTypes: () => apiClient.get("/api/resources/gpu-types"),
   getGroups: () => apiClient.get("/api/groups"),
   checkUbuntuUsername: (username) =>


### PR DESCRIPTION
## Summary
- admin_be의 `POST /api/admin/requests/{requestId}/migrate`가 프론트 어디에서도 호출되지 않고 있어 연동 추가
- FULFILLED 상태 신청서의 행 액션과 상세 모달에 "마이그레이션" 버튼 추가
- 후보 노드(쉼표 구분, 현재 노드 포함 필요)와 최소 개선 비율(선택)을 입력받는 모달
- config-server 처리 시간(최대 10분)에 맞춘 타임아웃, migrated/skipped 결과 및 409/502/타임아웃 에러 처리
- `apiClient.post()`가 `patch`/`delete`처럼 요청 옵션(타임아웃 등)을 받도록 확장

## Test plan
- [x] `npx eslint` — 0 errors (기존 raw px 경고 3건은 무관한 기존 코드)
- [x] `npx vite build` — 성공
- [ ] 배포 후 실제 FULFILLED 신청서로 마이그레이션 실행/스킵/에러 케이스 수동 확인 필요