### PR TITLE
fix: 재승인 시 이전 시도의 진행 단계 메시지가 잠깐 남아있는 문제 수정

### DIFF
--- a/src/pages/admin/RequestManagementPage.jsx
+++ b/src/pages/admin/RequestManagementPage.jsx
@@ -134,7 +134,13 @@ const RequestManagementPage = () => {
   const handleStatusUpdate = async (request, newStatus, comment = "") => {
     if (processingRequestId !== null) return;
     setProcessingRequestId(request.request_id);
-    if (newStatus === "FULFILLED") setProcessingUsername(request.ubuntu_username);
+    if (newStatus === "FULFILLED") {
+      // 같은 사용자를 재승인할 때는 provisioningTargetUsername이 안 바뀌어서
+      // 폴링 useEffect가 재실행되지 않는다 — 이전 실패 시도의 진행 단계 메시지가
+      // 첫 폴링(2초) 전까지 그대로 남아 보이는 걸 막기 위해 여기서 바로 지운다.
+      setProvisioningStatus(null);
+      setProcessingUsername(request.ubuntu_username);
+    }
     try {
       let response;
 


### PR DESCRIPTION
## Summary
- 같은 사용자를 재승인할 때 `provisioningTargetUsername`이 이전 시도와 동일해서 폴링 `useEffect`(dependency: `[provisioningTargetUsername]`)가 재실행되지 않음
- 그 결과 이전 실패 시도의 `provisioningStatus`(예: "pod_not_ready witin300s")가 첫 폴링(2초) 전까지 그대로 남아 보임
- `handleStatusUpdate`에서 승인 시작 시점에 `setProvisioningStatus(null)`을 바로 호출해 해결

## Test plan
- [x] `npx eslint` — 0 errors
- [x] `npx vite build` — 성공

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale provisioning progress messages from appearing when an approval is processed again for the same user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->