### PR TITLE
fix: 타임아웃 체인을 프론트 10분 고정 상한 기준으로 재정렬

### DIFF
--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -6,12 +6,11 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    # admin_be의 Pod 생성/마이그레이션 동기 처리(최대 600s)가 ingress-nginx 기본
-    # proxy-read-timeout(60s)에 끊기지 않도록 여유 있게 늘린다. (nginx.conf의
-    # 컨테이너 내부 프록시 타임아웃과 반드시 같이 맞춰야 한다.)
-    nginx.ingress.kubernetes.io/proxy-connect-timeout: "650"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "650"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "650"
+    # 타임아웃 체인: config-server(500s) < admin_be(550s) < 여기(570s) < 프론트(600s).
+    # (nginx.conf의 컨테이너 내부 프록시 타임아웃과 반드시 같이 맞춰야 한다.)
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "570"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "570"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "570"
 spec:
   ingressClassName: nginx-ailab
   rules:

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,11 +11,11 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Origin "";
-        # admin_be의 Pod 생성/마이그레이션 동기 처리(최대 600s)가 nginx 기본
-        # proxy_read_timeout(60s)에 끊기지 않도록 여유 있게 늘린다.
-        proxy_connect_timeout 650s;
-        proxy_send_timeout 650s;
-        proxy_read_timeout 650s;
+        # 타임아웃 체인: config-server(500s) < admin_be(550s) < 여기(570s) < 프론트(600s).
+        # nginx 기본 proxy_read_timeout(60s)에 끊기지 않도록 늘리되, 프론트보다는 짧게 잡는다.
+        proxy_connect_timeout 570s;
+        proxy_send_timeout 570s;
+        proxy_read_timeout 570s;
     }
 
     location /pod-status/ {
@@ -23,9 +23,9 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_connect_timeout 650s;
-        proxy_send_timeout 650s;
-        proxy_read_timeout 650s;
+        proxy_connect_timeout 570s;
+        proxy_send_timeout 570s;
+        proxy_read_timeout 570s;
     }
 
     location / {

--- a/src/services/requestService.js
+++ b/src/services/requestService.js
@@ -10,10 +10,10 @@ export const requestService = {
 
   approveRequest: (data) =>
     apiClient.patch("/api/admin/requests/approve", data, {
-      // 타임아웃은 안쪽 레이어보다 바깥쪽이 더 길어야 한다: config-server(550s)
-      // < admin_be podWebClient(600s) < nginx/ingress(650s) < 여기(프론트).
+      // 타임아웃 체인: config-server(500s) < admin_be(550s) < nginx/ingress(570s)
+      // < 여기(프론트, 600s=10분 — 사용자에게 보여주는 안내 문구와도 일치시킨다).
       // 짧게 잡으면 백엔드가 아직 정상 처리 중인데 프론트가 먼저 포기해버린다.
-      signal: AbortSignal.timeout(660_000),
+      signal: AbortSignal.timeout(600_000),
     }),
   rejectRequest: (data) => apiClient.patch("/api/admin/requests/reject", data),
 
@@ -37,9 +37,9 @@ export const requestService = {
       nodes,
       ...(minImprovementRatio != null && { minImprovementRatio }),
     }, {
-      // nginx/ingress 프록시 타임아웃(650s)보다 길게 잡아야 백엔드가 정상
+      // nginx/ingress 프록시 타임아웃(570s)보다 길게 잡아야 백엔드가 정상
       // 처리 중일 때 프론트가 먼저 타임아웃돼버리는 걸 막을 수 있다.
-      signal: AbortSignal.timeout(660_000),
+      signal: AbortSignal.timeout(600_000),
     }),
 
   getGpuTypes: () => apiClient.get("/api/resources/gpu-types"),


### PR DESCRIPTION
## Summary
- config-server(500s) < admin_be(550s) < nginx/ingress(570s) < 프론트(600s=10분) 체인으로 재정렬
- nginx.conf, k8s/ingress.yaml: 650s → 570s
- requestService.js: approveRequest/migrateRequest 660s → 600s
- admin_be의 `pod-timeout-seconds`는 GitHub Secret(`APPLICATION`)이라 이 PR로는 반영 안 됨 — 별도로 550s로 수동 갱신 필요

## Test plan
- [x] `npx eslint` — 0 errors
- [x] `npx vite build` — 성공
- [x] `ingress.yaml` YAML 파싱 확인