### PR TITLE
fix: 페이지 새로고침/재방문 시에도 PROCESSING 신청서 상태 폴링 유지

### DIFF
--- a/src/pages/admin/RequestManagementPage.jsx
+++ b/src/pages/admin/RequestManagementPage.jsx
@@ -47,17 +47,25 @@ const RequestManagementPage = () => {
   const [migrateFormError, setMigrateFormError] = useState(null);
   const [isMigrating, setIsMigrating] = useState(false);
 
+  // 목록에 PROCESSING 상태인 신청서가 있으면(다른 관리자가 처리 중이거나, 내가 승인 처리
+  // 중에 페이지를 나갔다가 새로고침해서 돌아온 경우) processingRequestId가 이번 세션에서
+  // 클릭한 적 없어도 그 신청서 기준으로 상태 배너/폴링을 이어간다.
+  const processingListRequest = requests.find((r) => r.status === "PROCESSING") || null;
+
   // 승인 처리 중(Pod 생성 포함)일 때 config-server의 세세한 진행 단계를 폴링해서 보여준다.
   // 조회 실패는 승인 흐름 자체에 영향을 주지 않으므로 조용히 무시한다.
+  const provisioningTargetUsername =
+    processingUsername || processingListRequest?.ubuntu_username || null;
+
   useEffect(() => {
-    if (!processingUsername) {
+    if (!provisioningTargetUsername) {
       setProvisioningStatus(null);
       return;
     }
     let cancelled = false;
     const poll = async () => {
       try {
-        const res = await podService.getProvisioningStatus(processingUsername);
+        const res = await podService.getProvisioningStatus(provisioningTargetUsername);
         if (!cancelled) setProvisioningStatus(res?.data ?? null);
       } catch {
         // ignore
@@ -69,7 +77,7 @@ const RequestManagementPage = () => {
       cancelled = true;
       clearInterval(interval);
     };
-  }, [processingUsername]);
+  }, [provisioningTargetUsername]);
 
   useEffect(() => {
     const fetchRequests = async () => {
@@ -439,9 +447,12 @@ const RequestManagementPage = () => {
           ]}
         />
       )}
-      {processingRequestId !== null ? (
+      {processingRequestId !== null || processingListRequest ? (
         <Alert type="info">
-          Pod 생성으로 승인 처리에 최대 10분이 걸릴 수 있습니다. 완료될 때까지 창을 닫거나 다시 클릭하지 마세요.
+          {processingListRequest && processingRequestId === null
+            ? `${processingListRequest.user_name}님의 신청서가 Pod 생성 처리 중입니다.`
+            : "Pod 생성으로 승인 처리에 최대 10분이 걸릴 수 있습니다."}{" "}
+          중복 클릭해도 안전하지만, 완료 전까지는 같은 신청서에 대한 새 승인 요청이 거부됩니다.
           {provisioningStatus?.message ? ` (현재 단계: ${provisioningStatus.message})` : null}
         </Alert>
       ) : null}


### PR DESCRIPTION
## Summary
- \`processingRequestId\`가 이번 세션에서 직접 승인 버튼을 눌렀을 때만 세팅되던 문제로, 승인 처리 중 페이지 이탈 후 재방문/새로고침하면 목록엔 PROCESSING으로 떠 있어도 상단 배너·폴링이 전혀 동작하지 않던 버그 수정
- 방금 불러온 \`requests\` 목록에서 PROCESSING 신청서를 찾아 그 사용자 기준으로 폴링을 이어가도록 함
- "다시 클릭하지 마세요" 문구를 실제 백엔드 보장(행 잠금 + 상태 전이로 중복 승인 차단)에 맞게 수정

## Test plan
- [x] \`npx eslint\` — 0 errors (기존 raw px 경고만 있음)
- [x] \`npx vite build\` — 성공