### PR TITLE
fix: 승인/거절 409 처리 시 '다른 관리자' 단정 문구 제거 및 처리중 거절 경고 추가

### DIFF
--- a/src/pages/admin/RequestManagementPage.jsx
+++ b/src/pages/admin/RequestManagementPage.jsx
@@ -210,10 +210,13 @@ const RequestManagementPage = () => {
       console.error("Failed to update request status:", error);
 
       if (error.status === 409) {
+        // 실제 원인은 두 가지다: ① 다른 관리자가 먼저 처리함 ② 본인이 새로고침 후 이미
+        // PROCESSING/처리 완료된 자신의 요청에 다시 클릭한 경우. 서버 응답만으로는 구분할
+        // 수 없으므로 원인을 단정하지 않고 사실만 안내한다.
         setAlert({
           type: "error",
           message:
-            "이 신청서는 이미 다른 관리자에 의해 처리되었습니다. 페이지를 새로고침해주세요.",
+            "처리 상태가 바뀌어 요청을 완료하지 못했습니다. 목록을 새로고침해 현재 상태를 확인해주세요.",
         });
       } else if (error.name === "TimeoutError" || error.name === "AbortError") {
         setAlert({
@@ -242,6 +245,14 @@ const RequestManagementPage = () => {
   };
 
   const promptDeny = (request) => {
+    // PROCESSING 상태는 Pod 생성이 이미 진행 중일 수 있다 — 진행 단계가 멈춘 것처럼
+    // 보인다고 오인해 실수로 취소하는 것을 막기 위해 별도로 확인한다.
+    if (request.status === "PROCESSING") {
+      const proceed = confirm(
+        "이 신청서는 현재 Pod 생성 처리 중입니다. 거절하면 진행 중인 계정/Pod가 정리됩니다. 계속하시겠습니까?"
+      );
+      if (!proceed) return;
+    }
     const comment = prompt("거절 사유를 입력하세요:", "거절되었습니다.");
     if (comment !== null) {
       handleStatusUpdate(request, "DENIED", comment || "거절되었습니다.");


### PR DESCRIPTION
## Summary
- approveRequest 409 에러가 항상 "다른 관리자에 의해 처리됨"으로 표시되던 문제 수정 — 실제로는 본인이 새로고침 후 이미 처리된 자신의 요청에 다시 클릭한 경우도 동일한 409로 내려와 원인을 구분할 수 없음. 상태 변경 사실만 안내하도록 문구 변경
- PROCESSING 상태 행의 거절 버튼에 확인 경고 추가 — Pod 생성이 멈춘 것처럼 보인다고 오인해 실수로 진행 중인 승인을 취소하는 것을 방지

## Related
Closes #67

## Test plan
- [x] `npx eslint src/pages/admin/RequestManagementPage.jsx` — 기존 warning 3건 외 신규 이슈 없음
- [x] `npm run build` 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified conflict alerts to cover multiple possible causes when updating request statuses.
  * Added a confirmation prompt before denying requests that are currently processing.
  * Prevented accidental denial when the confirmation is canceled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->