### PR TITLE
fix: 진행 상태 폴링 주기를 2초에서 1초로 단축

### DIFF
--- a/src/pages/admin/RequestManagementPage.jsx
+++ b/src/pages/admin/RequestManagementPage.jsx
@@ -72,7 +72,7 @@ const RequestManagementPage = () => {
       }
     };
     poll();
-    const interval = setInterval(poll, 2000);
+    const interval = setInterval(poll, 1000);
     return () => {
       cancelled = true;
       clearInterval(interval);


### PR DESCRIPTION
## Summary
- getProvisioningStatus 폴링 간격을 2000ms → 1000ms로 단축

## Related
Closes #69