### PR TITLE
feat: 관리자 콘솔에 사용자 비활성화/재활성화·권한변경 액션 연결

### DIFF
--- a/src/pages/admin/UserManagementPage.jsx
+++ b/src/pages/admin/UserManagementPage.jsx
@@ -84,6 +84,65 @@ const UserManagementPage = () => {
     }
   };
 
+  // 사용자 활성/비활성 토글
+  const handleToggleActive = async (user) => {
+    try {
+      const response = user.isActive
+        ? await userService.deactivateUser(user.userId)
+        : await userService.reactivateUser(user.userId);
+
+      if (response.status === 200) {
+        setAlert({
+          type: "success",
+          message: user.isActive
+            ? "사용자를 비활성화했습니다."
+            : "사용자를 재활성화했습니다.",
+        });
+        loadUsers();
+      } else {
+        setAlert({
+          type: "error",
+          message: user.isActive
+            ? "사용자 비활성화에 실패했습니다."
+            : "사용자 재활성화에 실패했습니다.",
+        });
+      }
+    } catch (error) {
+      console.error("사용자 활성 상태 변경 실패:", error);
+      setAlert({
+        type: "error",
+        message: `사용자 활성 상태 변경에 실패했습니다: ${error.message}`,
+      });
+    }
+  };
+
+  // 사용자 권한 토글 (ADMIN <-> USER)
+  const handleToggleRole = async (user) => {
+    const newRole = user.role === "ADMIN" ? "USER" : "ADMIN";
+    try {
+      const response = await userService.changeUserRole(user.userId, newRole);
+
+      if (response.status === 200) {
+        setAlert({
+          type: "success",
+          message: "사용자 권한을 변경했습니다.",
+        });
+        loadUsers();
+      } else {
+        setAlert({
+          type: "error",
+          message: "사용자 권한 변경에 실패했습니다.",
+        });
+      }
+    } catch (error) {
+      console.error("사용자 권한 변경 실패:", error);
+      setAlert({
+        type: "error",
+        message: `사용자 권한 변경에 실패했습니다: ${error.message}`,
+      });
+    }
+  };
+
   // 필터링된 사용자 목록
   const filteredUsers = users.filter((user) => {
     const matchesSearch =
@@ -177,12 +236,12 @@ const UserManagementPage = () => {
             {
               id: "toggle-active",
               text: user.isActive ? "비활성화" : "활성화",
-              disabled: true, // 백엔드 API 미구현
+              onClick: () => handleToggleActive(user),
             },
             {
               id: "toggle-role",
               text: user.role === "ADMIN" ? "사용자로 변경" : "관리자로 변경",
-              disabled: true, // 백엔드 API 미구현
+              onClick: () => handleToggleRole(user),
             },
             {
               id: "delete",

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -30,6 +30,52 @@ class UserService {
       throw error;
     }
   }
+
+  // 사용자 임시 비활성화 (계정/컨테이너는 유지, 로그인만 차단)
+  async deactivateUser(userId) {
+    try {
+      const response = await apiClient.request(`/api/admin/users/${userId}/deactivate`, {
+        method: "PATCH",
+      });
+
+      return response;
+    } catch (error) {
+      console.error("사용자 비활성화 실패:", error);
+      throw error;
+    }
+  }
+
+  // 비활성화된 사용자 재활성화
+  async reactivateUser(userId) {
+    try {
+      const response = await apiClient.request(`/api/admin/users/${userId}/reactivate`, {
+        method: "PATCH",
+      });
+
+      return response;
+    } catch (error) {
+      console.error("사용자 재활성화 실패:", error);
+      throw error;
+    }
+  }
+
+  // 사용자 권한 변경 (ADMIN <-> USER)
+  async changeUserRole(userId, role) {
+    try {
+      const response = await apiClient.request(`/api/admin/users/${userId}/role`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ role }),
+      });
+
+      return response;
+    } catch (error) {
+      console.error("사용자 권한 변경 실패:", error);
+      throw error;
+    }
+  }
 }
 
 const userService = new UserService();


### PR DESCRIPTION
## Summary
- userService.js에 deactivateUser, reactivateUser, changeUserRole 추가
- UserManagementPage.jsx의 "비활성화/활성화", "관리자로 변경/사용자로 변경" 드롭다운 항목을 실제 API 호출에 연결 (기존 disabled: true 해제)
- 대응 백엔드: CSID-DGU/admin_be#442 (develop 대상, 병합 후 main 배포 필요)

## Test plan
- [x] npx eslint — 신규 에러 없음 (기존 경고 3건은 무관)
- [x] CodeRabbit review --agent -t uncommitted — findings 0건
- [ ] 배포 후 실제 화면에서 활성/비활성 토글, 권한 변경 버튼 동작 확인

closes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Administrators can activate or deactivate user accounts from the user management page.
  * Administrators can change user roles between standard user and administrator.
  * Actions now provide success or error alerts and refresh the user list automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->