### PR TITLE
chore: 사용자 관리에서 삭제 액션 제거, 작업 컬럼을 케밥 메뉴로 통합

### DIFF
--- a/src/design-system/components/forms/ButtonDropdown.jsx
+++ b/src/design-system/components/forms/ButtonDropdown.jsx
@@ -7,7 +7,7 @@ import { Button } from "./Button.jsx";
  * per-row action menus in admin tables (Restart / Stop / Logs / Delete).
  * Items with variant "danger" render in the error color.
  */
-export function ButtonDropdown({ items = [], children = "작업", variant = "normal", onItemClick, style }) {
+export function ButtonDropdown({ items = [], children = "작업", variant = "normal", trigger = "label", ariaLabel, onItemClick, style }) {
   const [open, setOpen] = React.useState(false);
   const ref = React.useRef(null);
 
@@ -19,9 +19,18 @@ export function ButtonDropdown({ items = [], children = "작업", variant = "nor
 
   return (
     <div ref={ref} style={{ position: "relative", display: "inline-block", ...style }}>
-      <Button variant={variant} iconName="chevron-down" iconAlign="right" onClick={() => setOpen((o) => !o)}>
-        {children}
-      </Button>
+      {trigger === "icon" ? (
+        <Button
+          variant="icon"
+          iconName="ellipsis-vertical"
+          ariaLabel={ariaLabel ?? (typeof children === "string" ? children : "작업")}
+          onClick={() => setOpen((o) => !o)}
+        />
+      ) : (
+        <Button variant={variant} iconName="chevron-down" iconAlign="right" onClick={() => setOpen((o) => !o)}>
+          {children}
+        </Button>
+      )}
       {open ? (
         <div
           role="menu"

--- a/src/pages/admin/UserManagementPage.jsx
+++ b/src/pages/admin/UserManagementPage.jsx
@@ -10,7 +10,6 @@ import {
   Header,
   Input,
   KeyValuePairs,
-  Modal,
   Select,
   StatusIndicator,
   Table,
@@ -23,7 +22,6 @@ const UserManagementPage = () => {
   const [searchTerm, setSearchTerm] = useState("");
   const [filterRole, setFilterRole] = useState("ALL");
   const [filterStatus, setFilterStatus] = useState("ALL");
-  const [deleteTarget, setDeleteTarget] = useState(null); // { userId, name }
 
   // 사용자 목록 로드
   const loadUsers = async () => {
@@ -54,33 +52,6 @@ const UserManagementPage = () => {
       });
     } finally {
       setLoading(false);
-    }
-  };
-
-  // 사용자 삭제 (확인은 Modal에서 처리)
-  const handleDeleteUser = async (userId) => {
-    setDeleteTarget(null);
-    try {
-      const response = await userService.deleteUser(userId);
-
-      if (response.status === 200) {
-        setAlert({
-          type: "success",
-          message: "사용자가 성공적으로 삭제되었습니다.",
-        });
-        loadUsers(); // 목록 새로고침
-      } else {
-        setAlert({
-          type: "error",
-          message: "사용자 삭제에 실패했습니다.",
-        });
-      }
-    } catch (error) {
-      console.error("사용자 삭제 실패:", error);
-      setAlert({
-        type: "error",
-        message: "사용자 삭제에 실패했습니다.",
-      });
     }
   };
 
@@ -180,11 +151,29 @@ const UserManagementPage = () => {
       header: "사용자",
       minWidth: "180px",
       cell: (user) => (
-        <div>
-          <div className="font-medium text-(--decs-text-heading)">
-            {user.name}
+        <div className="flex items-center justify-between gap-2">
+          <div>
+            <div className="font-medium text-(--decs-text-heading)">
+              {user.name}
+            </div>
+            <div className="text-(--decs-text-secondary)">{user.email}</div>
           </div>
-          <div className="text-(--decs-text-secondary)">{user.email}</div>
+          <ButtonDropdown
+            trigger="icon"
+            ariaLabel={`${user.name} 관리`}
+            items={[
+              {
+                id: "toggle-active",
+                text: user.isActive ? "비활성화" : "활성화",
+                onClick: () => handleToggleActive(user),
+              },
+              {
+                id: "toggle-role",
+                text: user.role === "ADMIN" ? "사용자로 변경" : "관리자로 변경",
+                onClick: () => handleToggleRole(user),
+              },
+            ]}
+          />
         </div>
       ),
     },
@@ -225,37 +214,6 @@ const UserManagementPage = () => {
       id: "createdAt",
       header: "가입일",
       cell: (user) => formatDate(user.createdAt),
-    },
-    {
-      id: "actions",
-      header: "작업",
-      width: "110px",
-      cell: (user) => (
-        <ButtonDropdown
-          items={[
-            {
-              id: "toggle-active",
-              text: user.isActive ? "비활성화" : "활성화",
-              onClick: () => handleToggleActive(user),
-            },
-            {
-              id: "toggle-role",
-              text: user.role === "ADMIN" ? "사용자로 변경" : "관리자로 변경",
-              onClick: () => handleToggleRole(user),
-            },
-            {
-              id: "delete",
-              text: "삭제",
-              iconName: "trash",
-              variant: "danger",
-              onClick: () =>
-                setDeleteTarget({ userId: user.userId, name: user.name }),
-            },
-          ]}
-        >
-          작업
-        </ButtonDropdown>
-      ),
     },
   ];
 
@@ -358,36 +316,6 @@ const UserManagementPage = () => {
           ]}
         />
       </Container>
-
-      {/* 삭제 확인 */}
-      <Modal
-        visible={!!deleteTarget}
-        onDismiss={() => setDeleteTarget(null)}
-        header="사용자 삭제"
-        size="small"
-        footer={
-          <>
-            <Button onClick={() => setDeleteTarget(null)}>취소</Button>
-            <Button
-              variant="primary"
-              style={{
-                background: "var(--decs-status-error)",
-                color: "#fff",
-              }}
-              onClick={() => handleDeleteUser(deleteTarget.userId)}
-            >
-              삭제
-            </Button>
-          </>
-        }
-      >
-        {deleteTarget && (
-          <p>
-            사용자 &quot;{deleteTarget.name}&quot;이(가) 영구적으로 삭제됩니다.
-            이 작업은 되돌릴 수 없습니다.
-          </p>
-        )}
-      </Modal>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- "삭제"(deleteUser, 되돌릴 수 없음) 드롭다운 항목과 확인 모달 제거 — "비활성화"만 유지 (이제 동일한 컨테이너 정리 효과)
- 별도 "작업" 컬럼 제거, 사용자 컬럼 안에 아이콘 전용 케밥 트리거(ButtonDropdown trigger="icon")로 통합
- ButtonDropdown에 trigger="icon" 옵트인 prop 추가 (기존 라벨형 트리거는 그대로 유지, 다른 사용처 없어 영향 없음)

## Test plan
- [x] npx eslint — 신규 에러 없음
- [x] npm run build — 통과
- [ ] 브라우저에서 실제 렌더링 확인 필요 (이 세션에는 브라우저 접근 수단이 없어 코드 검증만 완료)

closes #73, closes #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an icon-only dropdown trigger option with accessible labeling.
  * Consolidated user management actions into a dropdown beside each user’s details.
  * Retained account activation and role management actions.

* **Changes**
  * Removed the user deletion option and its confirmation dialog from user management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->