### PR TITLE
fix: 상태 배지 텍스트가 좁은 컬럼에서 글자 단위로 줄바꿈됨

### DIFF
--- a/src/design-system/components/feedback/StatusIndicator.jsx
+++ b/src/design-system/components/feedback/StatusIndicator.jsx
@@ -33,10 +33,11 @@ export function StatusIndicator({ type = "info", children, iconSize = 16, style 
         fontFamily: "var(--decs-font-base)",
         fontSize: "var(--decs-fs-body-m)",
         lineHeight: "var(--decs-lh-body-m)",
+        whiteSpace: "nowrap",
         ...style,
       }}
     >
-      <span style={cfg.spin ? { display: "inline-flex", animation: "decs-spin 1s linear infinite" } : { display: "inline-flex" }}>
+      <span style={cfg.spin ? { display: "inline-flex", flexShrink: 0, animation: "decs-spin 1s linear infinite" } : { display: "inline-flex", flexShrink: 0 }}>
         <Icon name={cfg.icon} size={iconSize} />
       </span>
       <span style={{ color: "var(--decs-text-body)" }}>{statusKey ? t(`status.${statusKey}`) : children}</span>


### PR DESCRIPTION
## Summary
- StatusIndicator(공용 상태 배지)에 white-space: nowrap 추가
- 아이콘에 flex-shrink: 0 추가해 아이콘이 찌그러지지 않도록 함

## Test plan
- [x] npx eslint — 통과
- [x] npm run build — 통과

closes #76