### PR TITLE
chore: 사용자/이미지 관리 페이지를 decs-console 인라인 토큰 스타일로 통일 (1/4)

### DIFF
--- a/src/pages/admin/ImageManagementPage.jsx
+++ b/src/pages/admin/ImageManagementPage.jsx
@@ -117,7 +117,7 @@ const ImageManagementPage = () => {
       id: 'imageName',
       header: '이미지 이름',
       cell: (image) => (
-        <span className="font-medium text-(--decs-text-heading)">{image.imageName}</span>
+        <span style={{ fontWeight: 600, color: 'var(--decs-text-heading)' }}>{image.imageName}</span>
       ),
     },
     {
@@ -135,13 +135,13 @@ const ImageManagementPage = () => {
       id: 'createdAt',
       header: '생성일',
       cell: (image) => (
-        <span className="text-(--decs-text-secondary)">{formatDate(image.createdAt)}</span>
+        <span style={{ color: 'var(--decs-text-secondary)' }}>{formatDate(image.createdAt)}</span>
       ),
     },
   ];
 
   return (
-    <div className="space-y-6">
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--decs-space-l)' }}>
       <Header
         variant="h1"
         description="컨테이너 생성에 사용할 도커 이미지를 관리합니다."
@@ -166,14 +166,14 @@ const ImageManagementPage = () => {
 
       {showCreateForm && (
         <Container header={<Header variant="h2">새 이미지 생성</Header>}>
-          <div className="space-y-4">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <FormField label="이미지 이름" htmlFor="image-name">
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--decs-space-m)' }}>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--decs-space-m)' }}>
+              <FormField label="이미지 이름" htmlFor="image-name" constraintText="예: dguailab/decs (도커 레포지토리 경로, 이미지 ID 아님)">
                 <Input
                   id="image-name"
                   value={formData.imageName}
                   onChange={handleFieldChange('imageName')}
-                  placeholder="예: cuda"
+                  placeholder="예: dguailab/decs"
                 />
               </FormField>
               <FormField label="이미지 버전" htmlFor="image-version">
@@ -201,7 +201,7 @@ const ImageManagementPage = () => {
                 placeholder="이미지에 대한 설명을 입력하세요"
               />
             </FormField>
-            <div className="flex gap-2">
+            <div style={{ display: 'flex', gap: 'var(--decs-space-s)' }}>
               <Button variant="primary" loading={loading} onClick={handleCreateImage}>
                 생성
               </Button>

--- a/src/pages/admin/UserManagementPage.jsx
+++ b/src/pages/admin/UserManagementPage.jsx
@@ -151,12 +151,12 @@ const UserManagementPage = () => {
       header: "사용자",
       minWidth: "180px",
       cell: (user) => (
-        <div className="flex items-center justify-between gap-2">
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "var(--decs-space-xs)" }}>
           <div>
-            <div className="font-medium text-(--decs-text-heading)">
+            <div style={{ fontWeight: 600, color: "var(--decs-text-heading)" }}>
               {user.name}
             </div>
-            <div className="text-(--decs-text-secondary)">{user.email}</div>
+            <div style={{ color: "var(--decs-text-secondary)" }}>{user.email}</div>
           </div>
           <ButtonDropdown
             trigger="icon"
@@ -218,7 +218,7 @@ const UserManagementPage = () => {
   ];
 
   return (
-    <div className="space-y-6">
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-l)" }}>
       {/* 페이지 헤더 */}
       <Header
         variant="h1"
@@ -241,7 +241,7 @@ const UserManagementPage = () => {
 
       {/* 검색 및 필터 */}
       <Container>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: "var(--decs-space-m)" }}>
           <FormField label="검색" htmlFor="user-search">
             <Input
               id="user-search"


### PR DESCRIPTION
## Summary
- ImageManagementPage.jsx, UserManagementPage.jsx의 Tailwind className을 decs-console 인라인 style + 토큰 패턴으로 전환
- 이미지 이름 필드 안내 문구 추가 (도커 레포지토리 경로, 이미지 ID 아님)

## Test plan
- [x] npx eslint — 신규 에러 없음 (기존 컬럼 width px 경고는 무관)
- [x] npm run build — 통과

closes #78 (1/4 — RequestManagementPage, ChangeRequestManagementPage, MessageTemplatePage 후속)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated image and user management pages to use consistent design-system styling.
  * Improved layout and spacing for user search, filters, and management views.
  * Clarified the expected Docker repository path for image names and updated the example placeholder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->