### PR TITLE
feat: Pod 마이그레이션/삭제를 신청서 관리에서 컨테이너 상세로 이전

### DIFF
--- a/src/pages/admin/RequestManagementPage.jsx
+++ b/src/pages/admin/RequestManagementPage.jsx
@@ -41,11 +41,6 @@ const RequestManagementPage = () => {
   const [processingRequestId, setProcessingRequestId] = useState(null);
   const [processingUsername, setProcessingUsername] = useState(null);
   const [provisioningStatus, setProvisioningStatus] = useState(null);
-  const [migratingRequest, setMigratingRequest] = useState(null);
-  const [migrateNodesInput, setMigrateNodesInput] = useState("");
-  const [migrateRatioInput, setMigrateRatioInput] = useState("");
-  const [migrateFormError, setMigrateFormError] = useState(null);
-  const [isMigrating, setIsMigrating] = useState(false);
 
   // 목록에 PROCESSING 상태인 신청서가 있으면(다른 관리자가 처리 중이거나, 내가 승인 처리
   // 중에 페이지를 나갔다가 새로고침해서 돌아온 경우) processingRequestId가 이번 세션에서
@@ -259,81 +254,6 @@ const RequestManagementPage = () => {
     }
   };
 
-  const openMigrate = (request) => {
-    setMigratingRequest(request);
-    setMigrateNodesInput("");
-    setMigrateRatioInput("");
-    setMigrateFormError(null);
-  };
-
-  const closeMigrate = () => {
-    if (isMigrating) return;
-    setMigratingRequest(null);
-  };
-
-  const submitMigrate = async () => {
-    const nodes = migrateNodesInput
-      .split(",")
-      .map((n) => n.trim())
-      .filter(Boolean);
-
-    if (nodes.length === 0) {
-      setMigrateFormError("후보 노드를 하나 이상 입력하세요.");
-      return;
-    }
-
-    let minImprovementRatio;
-    if (migrateRatioInput.trim() !== "") {
-      const parsed = Number(migrateRatioInput.trim());
-      if (Number.isNaN(parsed)) {
-        setMigrateFormError("최소 개선 비율은 숫자로 입력하세요.");
-        return;
-      }
-      minImprovementRatio = parsed;
-    }
-
-    setMigrateFormError(null);
-    setIsMigrating(true);
-    try {
-      const response = await requestService.migrateRequest(
-        migratingRequest.request_id,
-        nodes,
-        minImprovementRatio
-      );
-      const result = response.data?.data ?? response.data;
-
-      if (result?.status === "migrated") {
-        setAlert({
-          type: "success",
-          message: `${migratingRequest.user_name}님의 Pod를 ${result.from} → ${result.to}(으)로 마이그레이션했습니다.${
-            result.old_pod_cleanup === "failed" ? " (기존 Pod 정리는 실패해 수동 확인이 필요합니다.)" : ""
-          }`,
-        });
-      } else {
-        setAlert({
-          type: "info",
-          message: `마이그레이션을 건너뛰었습니다: ${result?.reason ?? "개선 효과가 충분하지 않습니다."}${
-            result?.best_candidate ? ` (최적 후보: ${result.best_candidate})` : ""
-          }`,
-        });
-      }
-      setMigratingRequest(null);
-    } catch (error) {
-      console.error("Failed to migrate pod:", error);
-      if (error.status === 409) {
-        setMigrateFormError("이미 마이그레이션이 진행 중이거나 FULFILLED 상태가 아닙니다.");
-      } else if (error.status === 502) {
-        setMigrateFormError("config-server 마이그레이션 API 호출에 실패했습니다.");
-      } else if (error.name === "TimeoutError" || error.name === "AbortError") {
-        setMigrateFormError("응답 시간이 초과되었습니다. 실제 처리 상태는 목록을 새로고침해 확인해주세요.");
-      } else {
-        setMigrateFormError(error.message || "마이그레이션 요청에 실패했습니다.");
-      }
-    } finally {
-      setIsMigrating(false);
-    }
-  };
-
   const formatDate = (dateString) => {
     return new Date(dateString).toLocaleDateString("ko-KR", {
       year: "numeric",
@@ -419,11 +339,6 @@ const RequestManagementPage = () => {
               onClick={() => promptDeny(r)}
             >
               거절
-            </Button>
-          )}
-          {r.status === "FULFILLED" && (
-            <Button variant="inline-link" onClick={() => openMigrate(r)}>
-              마이그레이션
             </Button>
           )}
         </div>
@@ -533,11 +448,6 @@ const RequestManagementPage = () => {
               {sel.status === "PENDING" && (
                 <Button variant="primary" disabled={processingRequestId !== null} loading={processingRequestId === sel.request_id} onClick={() => promptApprove(sel)}>
                   승인
-                </Button>
-              )}
-              {sel.status === "FULFILLED" && (
-                <Button variant="primary" onClick={() => openMigrate(sel)}>
-                  마이그레이션
                 </Button>
               )}
             </>
@@ -701,55 +611,6 @@ const RequestManagementPage = () => {
         </Modal>
       )}
 
-      {/* Migrate Modal */}
-      {migratingRequest && (
-        <Modal
-          visible
-          onDismiss={closeMigrate}
-          header={`Pod 마이그레이션 — ${migratingRequest.user_name} (${migratingRequest.ubuntu_username})`}
-          footer={
-            <>
-              <Button variant="normal" disabled={isMigrating} onClick={closeMigrate}>
-                취소
-              </Button>
-              <Button variant="primary" loading={isMigrating} onClick={submitMigrate}>
-                마이그레이션 실행
-              </Button>
-            </>
-          }
-        >
-          <div className="space-y-4">
-            <Alert type="info">
-              config-server가 후보 노드 중 가장 개선 효과가 큰 노드로 Pod를 옮깁니다. 완료까지 최대 10분이 걸릴 수 있습니다.
-            </Alert>
-            <FormField
-              label="후보 노드"
-              description="현재 배포된 노드를 포함해 쉼표(,)로 구분해 입력하세요."
-              constraintText="예: farm1, farm2"
-              errorText={migrateFormError}
-            >
-              <Input
-                value={migrateNodesInput}
-                onChange={setMigrateNodesInput}
-                placeholder="farm1, farm2"
-                disabled={isMigrating}
-              />
-            </FormField>
-            <FormField
-              label="최소 개선 비율 (선택)"
-              description="생략하면 config-server 기본값을 사용합니다."
-            >
-              <Input
-                value={migrateRatioInput}
-                onChange={setMigrateRatioInput}
-                placeholder="0.2"
-                type="number"
-                disabled={isMigrating}
-              />
-            </FormField>
-          </div>
-        </Modal>
-      )}
     </div>
   );
 };

--- a/src/pages/decs-console/admin/AdminConsoleApp.jsx
+++ b/src/pages/decs-console/admin/AdminConsoleApp.jsx
@@ -74,7 +74,7 @@ function AdminConsoleApp() {
         <Routes>
           <Route index element={<AdminDashboard onOpenContainers={() => navigate("/admin/containers")} containers={containers ?? []} users={users ?? []} />} />
           <Route path="containers" element={<ContainerManagement onOpenDetail={(c) => navigate(`/admin/containers/${c.id}`)} containers={containers ?? []} />} />
-          <Route path="containers/:containerId" element={<ContainerDetailRoute containers={containers ?? []} />} />
+          <Route path="containers/:containerId" element={<ContainerDetailRoute containers={containers ?? []} onRefetch={refetch} />} />
           <Route path="requests" element={<RequestManagementPage />} />
           <Route path="change-requests" element={<ChangeRequestManagementPage />} />
           <Route path="users" element={<UserManagementPage />} />
@@ -87,11 +87,11 @@ function AdminConsoleApp() {
   );
 }
 
-function ContainerDetailRoute({ containers }) {
+function ContainerDetailRoute({ containers, onRefetch }) {
   const { containerId } = useParams();
   const navigate = useNavigate();
   const item = containers.find((container) => String(container.id) === containerId);
-  return <ContainerDetail item={item} onBack={() => navigate("/admin/containers")} />;
+  return <ContainerDetail item={item} onBack={() => navigate("/admin/containers")} onRefetch={onRefetch} />;
 }
 
 function getActiveHref(pathname) {

--- a/src/pages/decs-console/admin/ContainerDetail.jsx
+++ b/src/pages/decs-console/admin/ContainerDetail.jsx
@@ -1,8 +1,24 @@
 // ContainerDetail — 섹션(Container+Header) · 스펙(KeyValuePairs) · 탭(개요/로그/이벤트)
-import { Container, Header, KeyValuePairs, Tabs, StatusIndicator, BreadcrumbGroup } from "../../../design-system";
+import { useState } from "react";
+import {
+  Container, Header, KeyValuePairs, Tabs, StatusIndicator, BreadcrumbGroup,
+  Button, Modal, Alert, FormField, Input,
+} from "../../../design-system";
+import { requestService } from "../../../services/requestService";
+import userService from "../../../services/userService";
 
-function ContainerDetail({ item, onBack }) {
+function ContainerDetail({ item, onBack, onRefetch }) {
   const c = item;
+
+  const [alert, setAlert] = useState(null);
+  const [migrateOpen, setMigrateOpen] = useState(false);
+  const [migrateNodesInput, setMigrateNodesInput] = useState("");
+  const [migrateRatioInput, setMigrateRatioInput] = useState("");
+  const [migrateFormError, setMigrateFormError] = useState(null);
+  const [isMigrating, setIsMigrating] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState(null);
 
   if (!c) {
     return (
@@ -17,6 +33,93 @@ function ContainerDetail({ item, onBack }) {
       </div>
     );
   }
+
+  const openMigrate = () => {
+    setMigrateNodesInput("");
+    setMigrateRatioInput("");
+    setMigrateFormError(null);
+    setMigrateOpen(true);
+  };
+
+  const closeMigrate = () => {
+    if (isMigrating) return;
+    setMigrateOpen(false);
+  };
+
+  const submitMigrate = async () => {
+    const nodes = migrateNodesInput
+      .split(",")
+      .map((n) => n.trim())
+      .filter(Boolean);
+
+    if (nodes.length === 0) {
+      setMigrateFormError("후보 노드를 하나 이상 입력하세요.");
+      return;
+    }
+
+    let minImprovementRatio;
+    if (migrateRatioInput.trim() !== "") {
+      const parsed = Number(migrateRatioInput.trim());
+      if (Number.isNaN(parsed)) {
+        setMigrateFormError("최소 개선 비율은 숫자로 입력하세요.");
+        return;
+      }
+      minImprovementRatio = parsed;
+    }
+
+    setMigrateFormError(null);
+    setIsMigrating(true);
+    try {
+      const response = await requestService.migrateRequest(c.requestId, nodes, minImprovementRatio);
+      const result = response.data?.data ?? response.data;
+
+      if (result?.status === "migrated") {
+        setAlert({
+          type: "success",
+          message: `Pod를 ${result.from} → ${result.to}(으)로 마이그레이션했습니다.${
+            result.old_pod_cleanup === "failed" ? " (기존 Pod 정리는 실패해 수동 확인이 필요합니다.)" : ""
+          }`,
+        });
+      } else {
+        setAlert({
+          type: "info",
+          message: `마이그레이션을 건너뛰었습니다: ${result?.reason ?? "개선 효과가 충분하지 않습니다."}${
+            result?.best_candidate ? ` (최적 후보: ${result.best_candidate})` : ""
+          }`,
+        });
+      }
+      setMigrateOpen(false);
+      onRefetch?.();
+    } catch (error) {
+      console.error("Failed to migrate pod:", error);
+      if (error.status === 409) {
+        setMigrateFormError("이미 마이그레이션이 진행 중이거나 FULFILLED 상태가 아닙니다.");
+      } else if (error.status === 502) {
+        setMigrateFormError("config-server 마이그레이션 API 호출에 실패했습니다.");
+      } else if (error.name === "TimeoutError" || error.name === "AbortError") {
+        setMigrateFormError("응답 시간이 초과되었습니다. 실제 처리 상태는 목록을 새로고침해 확인해주세요.");
+      } else {
+        setMigrateFormError(error.message || "마이그레이션 요청에 실패했습니다.");
+      }
+    } finally {
+      setIsMigrating(false);
+    }
+  };
+
+  const submitDelete = async () => {
+    setDeleteError(null);
+    setIsDeleting(true);
+    try {
+      await userService.deleteUbuntuAccount(c.name);
+      onRefetch?.();
+      onBack();
+    } catch (error) {
+      console.error("Failed to delete container:", error);
+      setDeleteError(error.message || "컨테이너 삭제에 실패했습니다.");
+    } finally {
+      setIsDeleting(false);
+    }
+  };
 
   const overview = (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-l)" }}>
@@ -52,7 +155,30 @@ function ContainerDetail({ item, onBack }) {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-m)" }}>
       <BreadcrumbGroup items={[{ text: "컨테이너", href: "#" }, { text: c.name }]} onFollow={(it) => { if (it.href) onBack(); }} />
-      <Header variant="h1">
+
+      {alert && (
+        <Alert type={alert.type} dismissible onDismiss={() => setAlert(null)}>
+          {alert.message}
+        </Alert>
+      )}
+
+      <Header
+        variant="h1"
+        actions={
+          <div style={{ display: "flex", gap: "var(--decs-space-s)" }}>
+            {c.status !== "stopped" && c.requestId != null && (
+              <Button variant="normal" onClick={openMigrate}>마이그레이션</Button>
+            )}
+            <Button
+              variant="normal"
+              style={{ color: "var(--decs-status-error)", borderColor: "var(--decs-status-error)" }}
+              onClick={() => { setDeleteError(null); setDeleteOpen(true); }}
+            >
+              삭제
+            </Button>
+          </div>
+        }
+      >
         <span style={{ display: "inline-flex", alignItems: "center", gap: 10 }}>{c.name}</span>
       </Header>
       <Tabs tabs={[
@@ -60,6 +186,74 @@ function ContainerDetail({ item, onBack }) {
         { id: "logs", label: "로그", content: logs },
         { id: "events", label: "이벤트", content: events },
       ]} />
+
+      <Modal
+        visible={migrateOpen}
+        onDismiss={closeMigrate}
+        header={`Pod 마이그레이션 — ${c.userName ?? c.name} (${c.name})`}
+        footer={
+          <>
+            <Button variant="normal" disabled={isMigrating} onClick={closeMigrate}>취소</Button>
+            <Button variant="primary" loading={isMigrating} onClick={submitMigrate}>마이그레이션 실행</Button>
+          </>
+        }
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-m)" }}>
+          <Alert type="info">
+            config-server가 후보 노드 중 가장 개선 효과가 큰 노드로 Pod를 옮깁니다. 완료까지 최대 10분이 걸릴 수 있습니다.
+          </Alert>
+          <FormField
+            label="후보 노드"
+            description="현재 배포된 노드를 포함해 쉼표(,)로 구분해 입력하세요."
+            constraintText="예: farm1, farm2"
+            errorText={migrateFormError}
+          >
+            <Input
+              value={migrateNodesInput}
+              onChange={setMigrateNodesInput}
+              placeholder="farm1, farm2"
+              disabled={isMigrating}
+            />
+          </FormField>
+          <FormField label="최소 개선 비율 (선택)" description="생략하면 config-server 기본값을 사용합니다.">
+            <Input
+              value={migrateRatioInput}
+              onChange={setMigrateRatioInput}
+              placeholder="0.2"
+              type="number"
+              disabled={isMigrating}
+            />
+          </FormField>
+        </div>
+      </Modal>
+
+      <Modal
+        visible={deleteOpen}
+        onDismiss={() => !isDeleting && setDeleteOpen(false)}
+        header="컨테이너 삭제"
+        size="small"
+        footer={
+          <>
+            <Button variant="normal" disabled={isDeleting} onClick={() => setDeleteOpen(false)}>취소</Button>
+            <Button
+              variant="primary"
+              loading={isDeleting}
+              style={{ background: "var(--decs-status-error)", color: "#fff" }}
+              onClick={submitDelete}
+            >
+              삭제
+            </Button>
+          </>
+        }
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-s)" }}>
+          {deleteError ? <Alert type="error">{deleteError}</Alert> : null}
+          <p>
+            컨테이너 &quot;{c.name}&quot;이(가) 영구적으로 삭제됩니다 (외부 계정/Pod 정리 포함).
+            이 작업은 되돌릴 수 없습니다.
+          </p>
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -31,6 +31,20 @@ class UserService {
     }
   }
 
+  // 우분투 계정(컨테이너) 단독 삭제
+  async deleteUbuntuAccount(username) {
+    try {
+      const response = await apiClient.request(`/api/admin/users/ubuntu/${username}`, {
+        method: "DELETE",
+      });
+
+      return response;
+    } catch (error) {
+      console.error("컨테이너 삭제 실패:", error);
+      throw error;
+    }
+  }
+
   // 사용자 임시 비활성화 (계정/컨테이너는 유지, 로그인만 차단)
   async deactivateUser(userId) {
     try {

--- a/src/utils/decsMapper.js
+++ b/src/utils/decsMapper.js
@@ -72,8 +72,8 @@ export function mapPodStatus(podStatus) {
 }
 
 /**
- * @param {{ userId: string | number, userName: string, ubuntuUsername: string, podName: string, nodeName: string, imageName: string, imageVersion: string, resourceGroupId: string | number, expiresAt: string }} dto ContainerInfoDTO
- * @returns {{ id: string, name: string, user: string, gpu: string, node: string, status: string, label: string, expires: string }}
+ * @param {{ requestId: string | number, userId: string | number, userName: string, ubuntuUsername: string, podName: string, nodeName: string, imageName: string, imageVersion: string, resourceGroupId: string | number, expiresAt: string }} dto ContainerInfoDTO
+ * @returns {{ id: string, requestId: string | number, name: string, user: string, gpu: string, node: string, status: string, label: string, expires: string }}
  */
 export function mapAdminContainer(dto) {
   const status = mapPodStatus(dto.status);
@@ -82,6 +82,7 @@ export function mapAdminContainer(dto) {
 
   return {
     id: String(dto.ubuntuUsername ?? dto.userId),
+    requestId: dto.requestId,
     name: dto.ubuntuUsername ?? dto.userName ?? "—",
     user: dto.ubuntuUsername ?? dto.userName ?? "—",
     userName: dto.userName,


### PR DESCRIPTION
## Summary
- RequestManagementPage: 마이그레이션 버튼/모달/상태 제거
- ContainerDetail: 마이그레이션 + 삭제 버튼/모달 추가
- decsMapper: requestId 매핑 추가
- userService: deleteUbuntuAccount 추가
- 마이그레이션/삭제 성공 시 목록 자동 갱신 (onRefetch)

의존: admin_be#443 (ContainerInfoDTO.requestId) — 이미 배포됨

## Test plan
- [x] npx eslint — 신규 에러 없음
- [x] npm run build — 통과
- [ ] 실제 화면에서 마이그레이션/삭제 동작 확인 필요 (브라우저 접근 불가)

closes #82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added container migration and deletion actions in the admin console.
  - Added confirmation prompts, progress indicators, validation, and success/error notifications.
  - Container details can now refresh automatically after migration or deletion.

- **Bug Fixes**
  - Improved handling of Ubuntu account cleanup during container deletion.
  - Preserved request information when displaying container details.

- **Changes**
  - Removed migration actions from the admin request management page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->