### PR TITLE
chore: 나머지 관리자 페이지 3개를 decs-console 인라인 토큰 스타일로 통일 (2-4/4)

### DIFF
--- a/src/pages/admin/ChangeRequestManagementPage.jsx
+++ b/src/pages/admin/ChangeRequestManagementPage.jsx
@@ -333,7 +333,7 @@ const ChangeRequestManagementPage = () => {
       cell: (r) => (
         <div>
           <div>{r.requestedBy.name}</div>
-          <div className="text-(--decs-text-secondary)">
+          <div style={{ color: "var(--decs-text-secondary)" }}>
             {r.requestedBy.email}
           </div>
         </div>
@@ -373,7 +373,7 @@ const ChangeRequestManagementPage = () => {
       header: "작업",
       minWidth: "150px",
       cell: (r) => (
-        <div className="flex items-center gap-3">
+        <div style={{ display: "flex", alignItems: "center", gap: "var(--decs-space-s)" }}>
           <Button
             variant="inline-link"
             onClick={() => setSelectedChangeRequest(r)}
@@ -407,7 +407,7 @@ const ChangeRequestManagementPage = () => {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-64">
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: 256 }}>
         <StatusIndicator type="loading">
           변경 요청 목록을 불러오는 중...
         </StatusIndicator>
@@ -418,7 +418,7 @@ const ChangeRequestManagementPage = () => {
   const sel = selectedChangeRequest;
 
   return (
-    <div className="space-y-6">
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-l)" }}>
       {alert && (
         <Flashbar
           items={[
@@ -510,7 +510,7 @@ const ChangeRequestManagementPage = () => {
             </>
           }
         >
-          <div className="space-y-6">
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-l)" }}>
             <div>{renderStatus(sel.status)}</div>
             {sel.status === "PENDING" && APPROVAL_BLOCK_REASON[sel.changeType] && (
               <Alert type="warning" header="현재 승인할 수 없는 변경 유형입니다">
@@ -546,9 +546,9 @@ const ChangeRequestManagementPage = () => {
                   },
                 ]}
               />
-              <div className="mt-4">
-                <div className="text-(--decs-text-inactive) mb-1">변경 사유</div>
-                <div className="bg-(--decs-surface-sunken) p-3">
+              <div style={{ marginTop: "var(--decs-space-m)" }}>
+                <div style={{ color: "var(--decs-text-inactive)", marginBottom: "var(--decs-space-xxs)" }}>변경 사유</div>
+                <div style={{ background: "var(--decs-surface-sunken)", padding: "var(--decs-space-s)" }}>
                   {sel.reason}
                 </div>
               </div>
@@ -604,20 +604,20 @@ const ChangeRequestManagementPage = () => {
                     },
                   ]}
                 />
-                <div className="mt-4">
-                  <div className="text-(--decs-text-inactive) mb-1">
+                <div style={{ marginTop: "var(--decs-space-m)" }}>
+                  <div style={{ color: "var(--decs-text-inactive)", marginBottom: "var(--decs-space-xxs)" }}>
                     사용 목적
                   </div>
-                  <div className="bg-(--decs-surface-sunken) p-3">
+                  <div style={{ background: "var(--decs-surface-sunken)", padding: "var(--decs-space-s)" }}>
                     {sel.originalRequest.usagePurpose}
                   </div>
                 </div>
                 {sel.originalRequest.portMappings.length > 0 && (
-                  <div className="mt-4">
-                    <div className="text-(--decs-text-inactive) mb-1">
+                  <div style={{ marginTop: "var(--decs-space-m)" }}>
+                    <div style={{ color: "var(--decs-text-inactive)", marginBottom: "var(--decs-space-xxs)" }}>
                       포트 매핑
                     </div>
-                    <div className="flex flex-wrap gap-2">
+                    <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--decs-space-xs)" }}>
                       {sel.originalRequest.portMappings.map((port, index) => (
                         <Badge
                           key={index}

--- a/src/pages/admin/MessageTemplatePage.jsx
+++ b/src/pages/admin/MessageTemplatePage.jsx
@@ -108,14 +108,18 @@ const MessageTemplatePage = () => {
       id: 'key',
       header: '키',
       cell: (t) => (
-        <code className="font-(family-name:--decs-font-mono) text-(--decs-text-body)">{t.key}</code>
+        <code style={{ fontFamily: 'var(--decs-font-mono)', color: 'var(--decs-text-body)' }}>{t.key}</code>
       ),
     },
     {
       id: 'currentValue',
       header: '현재 값',
       minWidth: '280px',
-      cell: (t) => <p title={t.currentValue} className="truncate max-w-md m-0">{t.currentValue}</p>,
+      cell: (t) => (
+        <p title={t.currentValue} style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '28rem', margin: 0 }}>
+          {t.currentValue}
+        </p>
+      ),
     },
     {
       id: 'status',
@@ -132,7 +136,7 @@ const MessageTemplatePage = () => {
       header: '작업',
       width: '180px',
       cell: (t) => (
-        <div className="flex gap-2">
+        <div style={{ display: 'flex', gap: 'var(--decs-space-xs)' }}>
           <Button
             iconName="pencil-square"
             onClick={() => setEditing({ key: t.key, value: t.currentValue, defaultValue: t.defaultValue })}
@@ -150,7 +154,7 @@ const MessageTemplatePage = () => {
   ];
 
   return (
-    <div className="space-y-6">
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--decs-space-l)' }}>
       <Header variant="h1" description="알림 메시지 템플릿을 관리합니다.">
         양식 관리
       </Header>
@@ -163,13 +167,13 @@ const MessageTemplatePage = () => {
 
       {loading ? (
         <Container>
-          <div className="flex justify-center py-12">
+          <div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--decs-space-xl) 0' }}>
             <StatusIndicator type="in-progress">불러오는 중</StatusIndicator>
           </div>
         </Container>
       ) : templates.length === 0 ? (
         <Container>
-          <div className="text-center py-12 text-(--decs-text-secondary)">
+          <div style={{ textAlign: 'center', padding: 'var(--decs-space-xl) 0', color: 'var(--decs-text-secondary)' }}>
             등록된 메시지 템플릿이 없습니다.
           </div>
         </Container>
@@ -212,15 +216,15 @@ const MessageTemplatePage = () => {
         }
       >
         {editing && (
-          <div className="space-y-4">
-            <code className="block font-(family-name:--decs-font-mono) text-(--decs-text-secondary)">
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--decs-space-m)' }}>
+            <code style={{ display: 'block', fontFamily: 'var(--decs-font-mono)', color: 'var(--decs-text-secondary)' }}>
               {editing.key}
             </code>
 
             {editing.defaultValue && editing.defaultValue !== editing.value && (
-              <div className="bg-(--decs-surface-sunken) border border-(--decs-border-divider) p-3">
-                <p className="text-(--decs-text-inactive) mb-1 m-0">기본값</p>
-                <p className="text-(--decs-text-body) whitespace-pre-wrap m-0">
+              <div style={{ background: 'var(--decs-surface-sunken)', border: '1px solid var(--decs-border-divider)', padding: 'var(--decs-space-s)' }}>
+                <p style={{ color: 'var(--decs-text-inactive)', marginBottom: 'var(--decs-space-xxs)', marginTop: 0 }}>기본값</p>
+                <p style={{ color: 'var(--decs-text-body)', whiteSpace: 'pre-wrap', margin: 0 }}>
                   {editing.defaultValue}
                 </p>
               </div>
@@ -233,8 +237,16 @@ const MessageTemplatePage = () => {
             >
               <textarea
                 id="template-value"
-                className="w-full border border-(--decs-border-input) bg-(--decs-surface-input) text-(--decs-text-body) p-3 focus:outline-none focus:border-(--decs-border-focus) focus:ring-1 focus:ring-(--decs-border-focus)"
-                style={{ borderRadius: 'var(--decs-radius-input)', fontFamily: 'var(--decs-font-base)', fontSize: 'var(--decs-fs-body-m)' }}
+                style={{
+                  width: '100%', boxSizing: 'border-box', resize: 'vertical',
+                  border: '1px solid var(--decs-border-input)',
+                  background: 'var(--decs-surface-input)',
+                  color: 'var(--decs-text-body)',
+                  padding: 'var(--decs-space-s)',
+                  borderRadius: 'var(--decs-radius-input)',
+                  fontFamily: 'var(--decs-font-base)',
+                  fontSize: 'var(--decs-fs-body-m)',
+                }}
                 rows={5}
                 value={editing.value}
                 onChange={e => setEditing({ ...editing, value: e.target.value })}
@@ -265,8 +277,8 @@ const MessageTemplatePage = () => {
         }
       >
         {resetTarget && (
-          <p className="m-0">
-            <code className="font-(family-name:--decs-font-mono)">{resetTarget}</code>
+          <p style={{ margin: 0 }}>
+            <code style={{ fontFamily: 'var(--decs-font-mono)' }}>{resetTarget}</code>
             의 수정된 값이 삭제되고 기본값으로 복원됩니다.
           </p>
         )}

--- a/src/pages/admin/RequestManagementPage.jsx
+++ b/src/pages/admin/RequestManagementPage.jsx
@@ -291,7 +291,7 @@ const RequestManagementPage = () => {
       cell: (r) => (
         <div>
           <div>{r.user_name}</div>
-          <div className="text-(--decs-text-secondary)">
+          <div style={{ color: "var(--decs-text-secondary)" }}>
             {r.student_id} · {r.department}
           </div>
         </div>
@@ -322,7 +322,7 @@ const RequestManagementPage = () => {
       header: "작업",
       minWidth: "180px",
       cell: (r) => (
-        <div className="flex items-center gap-3">
+        <div style={{ display: "flex", alignItems: "center", gap: "var(--decs-space-s)" }}>
           <Button variant="inline-link" onClick={() => setSelectedRequest(r)}>
             상세
           </Button>
@@ -348,7 +348,7 @@ const RequestManagementPage = () => {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-64">
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: 256 }}>
         <StatusIndicator type="loading">
           신청서 목록을 불러오는 중...
         </StatusIndicator>
@@ -359,7 +359,7 @@ const RequestManagementPage = () => {
   const sel = selectedRequest;
 
   return (
-    <div className="space-y-6">
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-l)" }}>
       {alert && (
         <Flashbar
           items={[
@@ -453,7 +453,7 @@ const RequestManagementPage = () => {
             </>
           }
         >
-          <div className="space-y-6">
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-l)" }}>
             <div>{renderStatus(sel.status)}</div>
 
             <div>
@@ -526,16 +526,16 @@ const RequestManagementPage = () => {
                     : []),
                 ]}
               />
-              <div className="mt-4">
-                <div className="text-(--decs-text-inactive) mb-1">사용 목적</div>
-                <div className="bg-(--decs-surface-sunken) p-3">
+              <div style={{ marginTop: "var(--decs-space-m)" }}>
+                <div style={{ color: "var(--decs-text-inactive)", marginBottom: "var(--decs-space-xxs)" }}>사용 목적</div>
+                <div style={{ background: "var(--decs-surface-sunken)", padding: "var(--decs-space-s)" }}>
                   {sel.usage_purpose}
                 </div>
               </div>
               {sel.form_answers &&
                 Object.keys(sel.form_answers).length > 0 && (
-                  <div className="mt-4">
-                    <div className="text-(--decs-text-inactive) mb-1">
+                  <div style={{ marginTop: "var(--decs-space-m)" }}>
+                    <div style={{ color: "var(--decs-text-inactive)", marginBottom: "var(--decs-space-xxs)" }}>
                       추가 정보
                     </div>
                     <KeyValuePairs
@@ -554,7 +554,7 @@ const RequestManagementPage = () => {
             {sel.port_mappings && sel.port_mappings.length > 0 && (
               <div>
                 <Header variant="h3">외부 포트</Header>
-                <div className="flex flex-wrap gap-2 mt-2">
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--decs-space-xs)", marginTop: "var(--decs-space-xs)" }}>
                   {sel.port_mappings.map((port, index) => (
                     <Badge
                       key={index}
@@ -570,7 +570,7 @@ const RequestManagementPage = () => {
 
             <div>
               <Header variant="h3">처리 이력</Header>
-              <div className="space-y-2 mt-2">
+              <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-xs)", marginTop: "var(--decs-space-xs)" }}>
                 <StatusIndicator type="info">
                   신청 제출: {formatDate(sel.created_at)}
                 </StatusIndicator>
@@ -597,7 +597,7 @@ const RequestManagementPage = () => {
                 )}
               </div>
               {sel.admin_comment && (
-                <div className="mt-3">
+                <div style={{ marginTop: "var(--decs-space-s)" }}>
                   <Alert
                     type={sel.status === "DENIED" ? "error" : "info"}
                     header="관리자 의견"


### PR DESCRIPTION
## Summary
- RequestManagementPage, ChangeRequestManagementPage, MessageTemplatePage의 className을 인라인 style 토큰 패턴으로 전환
- #78과 합쳐 admin/ 하위 5개 레거시 페이지 전부 decs-console과 스타일 통일 완료

## Test plan
- [x] npx eslint — 신규 에러 없음
- [x] npm run build — 통과 (CSS 20.7KB → 18.3KB)

closes #84