### PR TITLE
feat: 마이그레이션 노드를 자유 텍스트 대신 목록에서 선택, 폰트 렌더링 차단 제거

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,19 @@
     <meta name="description" content="동국대학교 AI 연구실 GPU 서버 신청 및 관리 시스템" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!-- 렌더링 차단 방지: media=print로 비동기 로드 후 스타일 적용 (loadCSS 패턴) -->
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,600;0,700;1,400&family=Noto+Sans+KR:wght@400;500;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      media="print"
+      onload="this.media='all'"
+    />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,600;0,700;1,400&family=Noto+Sans+KR:wght@400;500;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      />
+    </noscript>
     <title>DGU AI Lab</title>
 
     <!-- Microsoft Clarity -->

--- a/src/design-system/tokens/typography.css
+++ b/src/design-system/tokens/typography.css
@@ -3,8 +3,10 @@
  * Korean text uses Noto Sans KR (matches CSID-DGU/admin_fe). Both from Google Fonts.
  * NOTE (font substitution): Open Sans + Noto Sans KR are loaded from Google Fonts
  * rather than shipped as local binaries. These ARE the real fonts, not a swap.
+ * NOTE (loading): the Google Fonts request itself is a <link> in index.html
+ * (loaded async), not an @import here — an @import inside our own bundled CSS
+ * forces the browser to fetch it serially before rendering anything.
  */
-@import url('https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,600;0,700;1,400&family=Noto+Sans+KR:wght@400;500;700&family=JetBrains+Mono:wght@400;500&display=swap');
 
 :root {
   /* Families */

--- a/src/pages/decs-console/admin/ContainerDetail.jsx
+++ b/src/pages/decs-console/admin/ContainerDetail.jsx
@@ -6,13 +6,16 @@ import {
 } from "../../../design-system";
 import { requestService } from "../../../services/requestService";
 import userService from "../../../services/userService";
+import { nodeService } from "../../../services/nodeService";
 
 function ContainerDetail({ item, onBack, onRefetch }) {
   const c = item;
 
   const [alert, setAlert] = useState(null);
   const [migrateOpen, setMigrateOpen] = useState(false);
-  const [migrateNodesInput, setMigrateNodesInput] = useState("");
+  const [availableNodes, setAvailableNodes] = useState([]);
+  const [nodesLoading, setNodesLoading] = useState(false);
+  const [selectedNodes, setSelectedNodes] = useState([]);
   const [migrateRatioInput, setMigrateRatioInput] = useState("");
   const [migrateFormError, setMigrateFormError] = useState(null);
   const [isMigrating, setIsMigrating] = useState(false);
@@ -34,11 +37,21 @@ function ContainerDetail({ item, onBack, onRefetch }) {
     );
   }
 
-  const openMigrate = () => {
-    setMigrateNodesInput("");
+  const openMigrate = async () => {
+    setSelectedNodes(c.node && c.node !== "—" ? [c.node] : []);
     setMigrateRatioInput("");
     setMigrateFormError(null);
     setMigrateOpen(true);
+    setNodesLoading(true);
+    try {
+      const response = await nodeService.getAllNodes();
+      setAvailableNodes(response.data?.data ?? response.data ?? []);
+    } catch (error) {
+      console.error("Failed to load nodes:", error);
+      setMigrateFormError("노드 목록을 불러오지 못했습니다.");
+    } finally {
+      setNodesLoading(false);
+    }
   };
 
   const closeMigrate = () => {
@@ -46,14 +59,17 @@ function ContainerDetail({ item, onBack, onRefetch }) {
     setMigrateOpen(false);
   };
 
+  const toggleNode = (nodeId) => {
+    setSelectedNodes((prev) =>
+      prev.includes(nodeId) ? prev.filter((n) => n !== nodeId) : [...prev, nodeId]
+    );
+  };
+
   const submitMigrate = async () => {
-    const nodes = migrateNodesInput
-      .split(",")
-      .map((n) => n.trim())
-      .filter(Boolean);
+    const nodes = selectedNodes;
 
     if (nodes.length === 0) {
-      setMigrateFormError("후보 노드를 하나 이상 입력하세요.");
+      setMigrateFormError("후보 노드를 하나 이상 선택하세요.");
       return;
     }
 
@@ -204,16 +220,42 @@ function ContainerDetail({ item, onBack, onRefetch }) {
           </Alert>
           <FormField
             label="후보 노드"
-            description="현재 배포된 노드를 포함해 쉼표(,)로 구분해 입력하세요."
-            constraintText="예: farm1, farm2"
+            description="마이그레이션을 시도할 노드를 하나 이상 선택하세요 (현재 노드 포함 가능)."
             errorText={migrateFormError}
           >
-            <Input
-              value={migrateNodesInput}
-              onChange={setMigrateNodesInput}
-              placeholder="farm1, farm2"
-              disabled={isMigrating}
-            />
+            {nodesLoading ? (
+              <div style={{ color: "var(--decs-text-secondary)", fontSize: "var(--decs-fs-body-s)" }}>노드 목록 불러오는 중...</div>
+            ) : availableNodes.length === 0 ? (
+              <div style={{ color: "var(--decs-text-secondary)", fontSize: "var(--decs-fs-body-s)" }}>사용 가능한 노드가 없습니다.</div>
+            ) : (
+              <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-xs)", maxHeight: 220, overflowY: "auto" }}>
+                {availableNodes.map((node) => (
+                  <label
+                    key={node.nodeId}
+                    style={{
+                      display: "flex", alignItems: "center", gap: "var(--decs-space-xs)",
+                      padding: "var(--decs-space-xs) var(--decs-space-s)",
+                      border: "1px solid var(--decs-border-container)",
+                      borderRadius: "var(--decs-radius-input)",
+                      background: node.nodeId === c.node ? "var(--decs-surface-sunken)" : "transparent",
+                      cursor: isMigrating ? "default" : "pointer",
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedNodes.includes(node.nodeId)}
+                      onChange={() => toggleNode(node.nodeId)}
+                      disabled={isMigrating}
+                    />
+                    <span style={{ fontWeight: 600, color: "var(--decs-text-heading)" }}>{node.nodeId}</span>
+                    <span style={{ color: "var(--decs-text-secondary)", fontSize: "var(--decs-fs-body-s)" }}>
+                      {node.resourceGroupName} · GPU {node.numberGpu}
+                      {node.nodeId === c.node ? " · 현재 노드" : ""}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            )}
           </FormField>
           <FormField label="최소 개선 비율 (선택)" description="생략하면 config-server 기본값을 사용합니다.">
             <Input

--- a/src/services/nodeService.js
+++ b/src/services/nodeService.js
@@ -1,0 +1,5 @@
+import apiClient from "./api.js";
+
+export const nodeService = {
+  getAllNodes: () => apiClient.get("/api/admin/nodes"),
+};


### PR DESCRIPTION
## Summary
- 마이그레이션 후보 노드 선택을 자유 텍스트 → 실제 노드 체크박스 목록으로 변경
- Google Fonts @import를 비동기 <link>로 이동해 CSS 렌더링 차단 제거

## Test plan
- [x] npx eslint — 신규 에러 없음
- [x] npm run build — 통과, CSS/JS 정상 minify 확인

closes #86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Migration workflows now display available nodes in a selectable checklist.
  * The current node is preselected and clearly highlighted.
  * Loading, empty, and error states provide clearer feedback when choosing migration targets.

* **Performance**
  * Fonts now load asynchronously to reduce render-blocking and improve initial page loading.
  * A fallback remains available when JavaScript is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->