### PR TITLE
fix: 대시보드 최근 컨테이너 클릭 시 상세로 이동 + 접근성 보강

### DIFF
--- a/src/design-system/components/feedback/ProgressBar.jsx
+++ b/src/design-system/components/feedback/ProgressBar.jsx
@@ -22,9 +22,16 @@ export function ProgressBar({ value = 0, status = "in-progress", label, descript
         </div>
       ) : null}
       {done ? (
-        <div style={{ fontSize: "var(--decs-fs-body-m)", color: FILL[status] }}>{resultText}</div>
+        <div role="status" style={{ fontSize: "var(--decs-fs-body-m)", color: FILL[status] }}>{resultText}</div>
       ) : (
-        <div style={{ height: "4px", borderRadius: "9999px", background: "var(--decs-grey-200)", overflow: "hidden" }}>
+        <div
+          role="progressbar"
+          aria-valuenow={pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={label || description || "진행률"}
+          style={{ height: "4px", borderRadius: "9999px", background: "var(--decs-grey-200)", overflow: "hidden" }}
+        >
           <div style={{ width: pct + "%", height: "100%", background: FILL[status], borderRadius: "9999px", transition: "width var(--decs-motion-slow) var(--decs-easing)" }} />
         </div>
       )}

--- a/src/design-system/components/layout/Modal.jsx
+++ b/src/design-system/components/layout/Modal.jsx
@@ -6,7 +6,21 @@ import { Icon } from "../icons/Icon.jsx";
  * actions (delete container, release volume) MUST go through a Modal confirm.
  * Pass footer actions via `footer` (usually Cancel + primary/danger button).
  */
+let modalIdCounter = 0;
+
 export function Modal({ visible, onDismiss, header, children, footer, size = "medium", style }) {
+  const titleId = React.useRef(`decs-modal-title-${++modalIdCounter}`).current;
+  const dialogRef = React.useRef(null);
+
+  React.useEffect(() => {
+    if (!visible) return;
+    // 열릴 때 포커스를 다이얼로그로 옮기고, 닫힐 때까지 Escape로 닫을 수 있게 함
+    dialogRef.current?.focus();
+    const onKeyDown = (e) => { if (e.key === "Escape") onDismiss?.(); };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [visible, onDismiss]);
+
   if (!visible) return null;
   const widths = { small: "400px", medium: "600px", large: "800px" };
   return (
@@ -21,8 +35,11 @@ export function Modal({ visible, onDismiss, header, children, footer, size = "me
       }}
     >
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
         style={{
           width: widths[size] || widths.medium, maxWidth: "100%", maxHeight: "80vh",
           display: "flex", flexDirection: "column",
@@ -31,7 +48,7 @@ export function Modal({ visible, onDismiss, header, children, footer, size = "me
         }}
       >
         <div style={{ display: "flex", alignItems: "flex-start", gap: "var(--decs-space-m)", padding: "var(--decs-space-xl) var(--decs-space-xl) var(--decs-space-m)" }}>
-          <h2 style={{ flex: 1, margin: 0, fontSize: "var(--decs-fs-heading-l)", lineHeight: "var(--decs-lh-heading-l)", fontWeight: "var(--decs-fw-bold)", color: "var(--decs-text-heading)" }}>{header}</h2>
+          <h2 id={titleId} style={{ flex: 1, margin: 0, fontSize: "var(--decs-fs-heading-l)", lineHeight: "var(--decs-lh-heading-l)", fontWeight: "var(--decs-fw-bold)", color: "var(--decs-text-heading)" }}>{header}</h2>
           <button onClick={onDismiss} aria-label="Close" style={{ background: "none", border: "none", cursor: "pointer", color: "var(--decs-text-secondary)", display: "inline-flex", padding: "var(--decs-space-xs)" }}>
             <Icon name="x-mark" size={18} />
           </button>

--- a/src/design-system/components/navigation/SideNavigation.jsx
+++ b/src/design-system/components/navigation/SideNavigation.jsx
@@ -10,6 +10,7 @@ function LinkItem({ item, activeHref, onFollow, depth = 0 }) {
   return (
     <a
       href={item.href}
+      aria-current={active ? "page" : undefined}
       onClick={(e) => { if (onFollow) { e.preventDefault(); onFollow(item); } }}
       style={{
         display: "flex", alignItems: "center", gap: "var(--decs-space-xs)",
@@ -33,7 +34,7 @@ function LinkItem({ item, activeHref, onFollow, depth = 0 }) {
 
 export function SideNavigation({ header, items = [], activeHref, onFollow, style }) {
   return (
-    <nav style={{ width: "100%", height: "100%", background: "var(--decs-surface-nav)", borderRight: "1px solid var(--decs-border-divider)", padding: "var(--decs-space-m) var(--decs-space-s)", boxSizing: "border-box", fontFamily: "var(--decs-font-base)", overflowY: "auto", ...style }}>
+    <nav aria-label={header?.text || "주 메뉴"} style={{ width: "100%", height: "100%", background: "var(--decs-surface-nav)", borderRight: "1px solid var(--decs-border-divider)", padding: "var(--decs-space-m) var(--decs-space-s)", boxSizing: "border-box", fontFamily: "var(--decs-font-base)", overflowY: "auto", ...style }}>
       {header ? (
         <div style={{ padding: "0 var(--decs-space-s) var(--decs-space-s)", borderBottom: "1px solid var(--decs-border-divider)", marginBottom: "var(--decs-space-s)" }}>
           <a title={header.text} href={header.href} onClick={(e) => { if (onFollow) { e.preventDefault(); onFollow(header); } }} style={{ display: "block", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", fontSize: "var(--decs-fs-heading-s)", fontWeight: "var(--decs-fw-bold)", color: "var(--decs-text-heading)", textDecoration: "none" }}>{header.text}</a>

--- a/src/pages/decs-console/admin/AdminConsoleApp.jsx
+++ b/src/pages/decs-console/admin/AdminConsoleApp.jsx
@@ -72,7 +72,7 @@ function AdminConsoleApp() {
       >
         {error && (location.pathname === "/admin" || location.pathname.startsWith("/admin/containers")) ? <div style={{ marginBottom: "var(--decs-space-m)" }}><Flashbar items={[{ id: "decs-admin-data", type: "warning", header: error, dismissible: false }]} /></div> : null}
         <Routes>
-          <Route index element={<AdminDashboard onOpenContainers={() => navigate("/admin/containers")} containers={containers ?? []} users={users ?? []} />} />
+          <Route index element={<AdminDashboard onOpenContainers={() => navigate("/admin/containers")} onOpenDetail={(c) => navigate(`/admin/containers/${c.id}`)} containers={containers ?? []} users={users ?? []} />} />
           <Route path="containers" element={<ContainerManagement onOpenDetail={(c) => navigate(`/admin/containers/${c.id}`)} containers={containers ?? []} />} />
           <Route path="containers/:containerId" element={<ContainerDetailRoute containers={containers ?? []} onRefetch={refetch} />} />
           <Route path="requests" element={<RequestManagementPage />} />

--- a/src/pages/decs-console/admin/AdminDashboard.jsx
+++ b/src/pages/decs-console/admin/AdminDashboard.jsx
@@ -11,7 +11,7 @@ function StatCard({ label, value, sub, accent }) {
   );
 }
 
-function AdminDashboard({ onOpenContainers, containers = [], users = [] }) {
+function AdminDashboard({ onOpenContainers, onOpenDetail, containers = [], users = [] }) {
   const running = containers.filter((c) => c.status === "success").length;
   const errored = containers.filter((c) => c.status === "error").length;
   const expiring = containers.filter((c) => c.status !== "stopped" && c.expires !== "—" && c.expires <= "2026-07-11").length;
@@ -48,7 +48,19 @@ function AdminDashboard({ onOpenContainers, containers = [], users = [] }) {
 
         <Container disablePadding header={<Header variant="h2" counter={`(${containers.length})`} actions={<Button variant="link" onClick={onOpenContainers}>전체 보기</Button>}>최근 컨테이너</Header>}>
           <Table density="compact" trackBy="id" items={recentContainers.slice(0, 5)} columns={[
-            { id: "name", header: "이름", cell: (c) => <span style={{ fontWeight: 600 }}>{c.name}</span> },
+            {
+              id: "name",
+              header: "이름",
+              cell: (c) => (
+                <a
+                  href="#"
+                  onClick={(e) => { e.preventDefault(); onOpenDetail?.(c); }}
+                  style={{ fontWeight: 600, color: "var(--decs-text-link)", textDecoration: "none" }}
+                >
+                  {c.name}
+                </a>
+              ),
+            },
             { id: "user", header: "사용자", cell: (c) => c.user },
             { id: "gpu", header: "리소스 그룹", cell: (c) => <Badge color="brand">{c.gpu}</Badge> },
             { id: "status", header: "상태", cell: (c) => <StatusIndicator type={c.status}>{c.label}</StatusIndicator> },


### PR DESCRIPTION
## Summary
- 대시보드 최근 컨테이너 클릭 시 상세 페이지로 이동
- Modal/ProgressBar/SideNavigation 접근성 보강

## Test plan
- [x] npx eslint — 신규 에러 없음
- [x] npm run build — 통과

closes #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved progress indicators with screen reader-friendly status and progress information.
  - Enhanced modal accessibility with proper title association, focus management, and Escape-key dismissal.
  - Added clearer navigation labels and active-page announcements.

- **New Features**
  - Recent container names in the admin dashboard are now clickable and open the selected container’s detail view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->