### PR TITLE
fix: 변경 요청 거절 시 사유 입력을 비워두면 아무 동작도 안 함

### DIFF
--- a/src/pages/admin/ChangeRequestManagementPage.jsx
+++ b/src/pages/admin/ChangeRequestManagementPage.jsx
@@ -292,9 +292,9 @@ const ChangeRequestManagementPage = () => {
   };
 
   const promptDeny = (changeRequest) => {
-    const comment = prompt("거절 사유를 입력하세요:");
-    if (comment) {
-      handleStatusUpdate(changeRequest, "DENIED", comment);
+    const comment = prompt("거절 사유를 입력하세요:", "거절되었습니다.");
+    if (comment !== null) {
+      handleStatusUpdate(changeRequest, "DENIED", comment || "거절되었습니다.");
     }
   };
 


### PR DESCRIPTION
## Summary
- promptDeny의 if (comment) → comment !== null + 기본값 폴백으로 수정

## Test plan
- [x] npx eslint / npm run build — 통과

closes #96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the request-denial prompt with a default rejection reason.
  * Empty comments now correctly use the default reason when denying a request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->