### PR TITLE
fix: HTTP 환경에서 복사 버튼이 실제로는 복사하지 않던 문제 수정

### DIFF
--- a/src/design-system/components/data/KeyValuePairs.jsx
+++ b/src/design-system/components/data/KeyValuePairs.jsx
@@ -2,6 +2,37 @@ import React from "react";
 import { Icon } from "../icons/Icon.jsx";
 
 /**
+ * navigator.clipboard는 보안 컨텍스트(HTTPS/localhost)에서만 존재한다. 이 사이트는
+ * 현재 평문 HTTP로 서빙되므로 그 API가 undefined라 조용히 아무 일도 안 한다 —
+ * document.execCommand("copy") 폴백은 HTTP에서도 동작한다.
+ */
+async function copyToClipboard(text) {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // 폴백으로 계속 진행
+    }
+  }
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  let success = false;
+  try {
+    success = document.execCommand("copy");
+  } catch {
+    success = false;
+  }
+  document.body.removeChild(textarea);
+  return success;
+}
+
+/**
  * KeyValuePairs — labeled read-only detail pairs (resource spec, uid/gid,
  * volume, SSH access info). Lays out across `columns`. A value may include a
  * copy button via item.copyable + copyText.
@@ -12,7 +43,13 @@ function CopyValue({ text }) {
     <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}>
       <code style={{ fontFamily: "var(--decs-font-mono)", fontSize: "var(--decs-fs-body-s)", background: "var(--decs-grey-100)", padding: "1px 6px", borderRadius: "var(--decs-radius-badge)", color: "var(--decs-text-body)" }}>{text}</code>
       <button
-        onClick={() => { try { navigator.clipboard?.writeText(text); } catch { /* clipboard 미지원 환경은 무시 */ } setCopied(true); setTimeout(() => setCopied(false), 1200); }}
+        onClick={async () => {
+          const success = await copyToClipboard(text);
+          if (success) {
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1200);
+          }
+        }}
         aria-label="복사" style={{ background: "none", border: "none", cursor: "pointer", color: copied ? "var(--decs-status-success)" : "var(--decs-text-secondary)", display: "inline-flex", padding: 0 }}
       >
         <Icon name={copied ? "check" : "clipboard"} size={14} />


### PR DESCRIPTION
## 요약
- `navigator.clipboard`는 HTTPS/localhost에서만 존재하는 API인데, 현재 사이트가 HTTP로 서빙되고 있어 복사 버튼을 눌러도 실제로는 아무 것도 복사되지 않고 성공 아이콘만 뜨던 문제 수정
- `document.execCommand("copy")` 폴백 추가로 HTTP 환경에서도 실제 복사 동작하도록 수정
- 복사가 실제로 성공했을 때만 체크 아이콘 표시

## 테스트
- [x] `npx eslint` 통과
- [x] `npm run build` 통과

closes #98