### PR TITLE
fix: PROCESSING/MIGRATING 상태 프론트 가시성 누락 및 Clarity 쿠키 경고

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,13 +24,17 @@
     </noscript>
     <title>DGU AI Lab</title>
 
-    <!-- Microsoft Clarity -->
+    <!-- Microsoft Clarity: IP 주소로 접속하면 세션 쿠키(_clsk)의 Domain 속성이 유효하지
+         않아 브라우저가 거부하고 콘솔에 경고를 남긴다. 실제 도메인에서만 로드해 그 경고를
+         원천 차단한다 — 어차피 IP 접속에서는 크로스페이지 세션 추적도 정상 동작하지 않는다. -->
     <script type="text/javascript">
-      (function(c,l,a,r,i,t,y){
-        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-      })(window, document, "clarity", "script", "xelxgi7ss0");
+      if (!/^(\d{1,3}\.){3}\d{1,3}$/.test(location.hostname)) {
+        (function(c,l,a,r,i,t,y){
+          c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+          t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+          y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+        })(window, document, "clarity", "script", "xelxgi7ss0");
+      }
     </script>
 
     <!-- Google Analytics 4 -->

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -9,5 +9,5 @@
   "shell": {
     "adminTitle": "DECS Admin Console", "userTitle": "DGU GPU Portal", "dashboard": "Dashboard", "containers": "Containers", "myContainer": "My container", "gpuRequest": "GPU request", "requests": "Requests", "requestManagement": "Request management", "changeRequests": "Change requests", "changeManagement": "Change management", "users": "Users", "system": "System", "monitoring": "Monitoring", "resourceMonitoring": "Resource monitoring", "images": "Images", "templates": "Message templates", "account": "Account"
   },
-  "status": { "running": "Running", "provisioning": "Provisioning", "error": "Error", "stopped": "Stopped", "pending": "Pending approval", "denied": "Denied", "unknown": "Unknown" }
+  "status": { "running": "Running", "provisioning": "Provisioning", "error": "Error", "stopped": "Stopped", "pending": "Pending approval", "denied": "Denied", "unknown": "Unknown", "migrating": "Migrating", "deleted": "Deleted" }
 }

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -9,5 +9,5 @@
   "shell": {
     "adminTitle": "DECS 관리자 콘솔", "userTitle": "DGU GPU 포털", "dashboard": "대시보드", "containers": "컨테이너 관리", "myContainer": "내 컨테이너", "gpuRequest": "GPU 신청", "requests": "신청 현황", "requestManagement": "신청서 관리", "changeRequests": "변경 요청 현황", "changeManagement": "변경 요청 관리", "users": "사용자 관리", "system": "시스템", "monitoring": "모니터링", "resourceMonitoring": "리소스 모니터링", "images": "이미지", "templates": "메시지 템플릿", "account": "계정 설정"
   },
-  "status": { "running": "실행 중", "provisioning": "프로비저닝 중", "error": "오류", "stopped": "종료", "pending": "승인 대기", "denied": "거절됨", "unknown": "알 수 없음" }
+  "status": { "running": "실행 중", "provisioning": "프로비저닝 중", "error": "오류", "stopped": "종료", "pending": "승인 대기", "denied": "거절됨", "unknown": "알 수 없음", "migrating": "마이그레이션 중", "deleted": "삭제됨" }
 }

--- a/src/pages/admin/RequestManagementPage.jsx
+++ b/src/pages/admin/RequestManagementPage.jsx
@@ -142,6 +142,7 @@ const RequestManagementPage = () => {
 
   const statusCounts = {
     PENDING: requestsInPeriod.filter((r) => r.status === "PENDING").length,
+    PROCESSING: requestsInPeriod.filter((r) => r.status === "PROCESSING").length,
     FULFILLED: requestsInPeriod.filter((r) => r.status === "FULFILLED").length,
     DENIED: requestsInPeriod.filter((r) => r.status === "DENIED").length,
     DELETED: requestsInPeriod.filter((r) => r.status === "DELETED").length,
@@ -299,6 +300,8 @@ const RequestManagementPage = () => {
   const emptyText = `${
     filter === "PENDING"
       ? "대기중인"
+      : filter === "PROCESSING"
+      ? "처리중인"
       : filter === "FULFILLED"
       ? "승인된"
       : filter === "DENIED"
@@ -423,6 +426,7 @@ const RequestManagementPage = () => {
         <Tabs
           tabs={[
             { key: "PENDING", label: "대기중" },
+            { key: "PROCESSING", label: "처리중" },
             { key: "FULFILLED", label: "승인됨" },
             { key: "DENIED", label: "거절됨" },
             { key: "DELETED", label: "삭제됨" },

--- a/src/utils/decsMapper.js
+++ b/src/utils/decsMapper.js
@@ -22,8 +22,11 @@ const STATUS_MAP = {
   waiting_ready: { type: "in-progress", key: "provisioning" },
   creating_services: { type: "in-progress", key: "provisioning" },
   PENDING: { type: "pending", key: "pending" },
+  PROCESSING: { type: "in-progress", key: "provisioning" },
   FULFILLED: { type: "success", key: "running" },
   DENIED: { type: "error", key: "denied" },
+  MIGRATING: { type: "in-progress", key: "migrating" },
+  DELETED: { type: "stopped", key: "deleted" },
 };
 
 function formatDate(dateStr) {


### PR DESCRIPTION
Closes #100

## Summary
- RequestManagementPage에 PROCESSING 탭 추가
- decsMapper STATUS_MAP에 PROCESSING/MIGRATING/DELETED 매핑 추가 (ko/en 라벨 포함)
- Clarity 스크립트를 실제 도메인 접속일 때만 로드

## Test plan
- [x] `npx eslint` 클린 (새 경고/에러 없음)
- [x] `npm run build` 성공

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Processing” filtering and request counts to the admin request management page.
  * Added visible status labels for Processing, Migrating, and Deleted requests.
  * Added English and Korean translations for the new statuses.

* **Bug Fixes**
  * Prevented analytics tracking from loading on IP-address access, avoiding invalid cookie-domain browser warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->