### PR TITLE
fix: 요청/모달 UX 버그 수정 + 사이드바 뱃지 + 마이그레이션 필수 옵션

### DIFF
--- a/src/design-system/components/layout/Modal.jsx
+++ b/src/design-system/components/layout/Modal.jsx
@@ -12,10 +12,17 @@ export function Modal({ visible, onDismiss, header, children, footer, size = "me
   const titleId = React.useRef(`decs-modal-title-${++modalIdCounter}`).current;
   const dialogRef = React.useRef(null);
 
+  // 열릴 때 한 번만 포커스를 다이얼로그로 옮긴다. onDismiss는 대부분 호출부에서
+  // 인라인 함수로 넘어와 렌더마다 참조가 바뀌므로, 이 effect의 의존성에 넣으면
+  // 다이얼로그 안 입력 필드에 한 글자 칠 때마다(부모 리렌더 → onDismiss 재생성)
+  // 포커스가 다이얼로그 컨테이너로 다시 뺏겨서 한 글자씩만 입력되는 버그가 생긴다.
   React.useEffect(() => {
     if (!visible) return;
-    // 열릴 때 포커스를 다이얼로그로 옮기고, 닫힐 때까지 Escape로 닫을 수 있게 함
     dialogRef.current?.focus();
+  }, [visible]);
+
+  React.useEffect(() => {
+    if (!visible) return;
     const onKeyDown = (e) => { if (e.key === "Escape") onDismiss?.(); };
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);

--- a/src/hooks/useDecsAdminData.js
+++ b/src/hooks/useDecsAdminData.js
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { podService } from "../services/podService";
 import userService from "../services/userService";
+import { requestService } from "../services/requestService";
 import { mapAdminContainer } from "../utils/decsMapper";
 
 const ERROR_MESSAGE = "일부 Pod 상세 정보를 불러오지 못했습니다.";
@@ -14,17 +15,30 @@ function getArrayData(res) {
 export function useDecsAdminData() {
   const [containers, setContainers] = useState(undefined);
   const [users, setUsers] = useState(undefined);
+  const [pendingRequestCount, setPendingRequestCount] = useState(0);
+  const [pendingChangeRequestCount, setPendingChangeRequestCount] = useState(0);
   const [error, setError] = useState(null);
   const cancelledRef = useRef(false);
 
   const load = useCallback(async () => {
     setError(null);
 
-    const [containersResult, usersResult] = await Promise.allSettled([
+    const [containersResult, usersResult, requestsResult, changeRequestsResult] = await Promise.allSettled([
       podService.getActiveContainers(),
       userService.getAllUsers(),
+      requestService.getAllRequests(),
+      requestService.getChangeRequests(),
     ]);
     if (cancelledRef.current) return;
+
+    if (requestsResult.status === "fulfilled") {
+      const requestsArray = getArrayData(requestsResult.value) ?? [];
+      setPendingRequestCount(requestsArray.filter((r) => r.status === "PENDING").length);
+    }
+    if (changeRequestsResult.status === "fulfilled") {
+      const changeRequestsArray = getArrayData(changeRequestsResult.value) ?? [];
+      setPendingChangeRequestCount(changeRequestsArray.filter((r) => r.status === "PENDING").length);
+    }
 
     let hasError = false;
 
@@ -80,5 +94,5 @@ export function useDecsAdminData() {
     };
   }, [load]);
 
-  return { containers, users, error, refetch: load };
+  return { containers, users, pendingRequestCount, pendingChangeRequestCount, error, refetch: load };
 }

--- a/src/pages/decs-console/admin/AdminConsoleApp.jsx
+++ b/src/pages/decs-console/admin/AdminConsoleApp.jsx
@@ -20,7 +20,7 @@ function AdminConsoleApp() {
   const navigate = useNavigate();
   const { user, logout } = useAuth();
   const { t, i18n } = useTranslation();
-  const { containers, users, error, refetch } = useDecsAdminData();
+  const { containers, users, pendingRequestCount, pendingChangeRequestCount, error, refetch } = useDecsAdminData();
 
   // 요청 관리 화면에서 승인/거절 처리 후 대시보드로 돌아왔을 때 최신 상태가 바로 보이도록,
   // 대시보드 관련 경로에 진입할 때마다 다시 불러온다.
@@ -37,8 +37,8 @@ function AdminConsoleApp() {
     items: [
       { text: t("shell.dashboard"), href: "/admin", icon: "home" },
       { text: t("shell.containers"), href: "/admin/containers", icon: "cube", badge: containers?.length ?? 0 },
-      { text: t("shell.requestManagement"), href: "/admin/requests", icon: "document-text" },
-      { text: t("shell.changeManagement"), href: "/admin/change-requests", icon: "arrow-path" },
+      { text: t("shell.requestManagement"), href: "/admin/requests", icon: "document-text", badge: pendingRequestCount },
+      { text: t("shell.changeManagement"), href: "/admin/change-requests", icon: "arrow-path", badge: pendingChangeRequestCount },
       { text: t("shell.users"), href: "/admin/users", icon: "users" },
       { type: "divider" },
       { type: "section", text: t("shell.system"), items: [

--- a/src/pages/decs-console/admin/ContainerDetail.jsx
+++ b/src/pages/decs-console/admin/ContainerDetail.jsx
@@ -17,6 +17,7 @@ function ContainerDetail({ item, onBack, onRefetch }) {
   const [nodesLoading, setNodesLoading] = useState(false);
   const [selectedNodes, setSelectedNodes] = useState([]);
   const [migrateRatioInput, setMigrateRatioInput] = useState("");
+  const [migrateForce, setMigrateForce] = useState(false);
   const [migrateFormError, setMigrateFormError] = useState(null);
   const [isMigrating, setIsMigrating] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -40,6 +41,7 @@ function ContainerDetail({ item, onBack, onRefetch }) {
   const openMigrate = async () => {
     setSelectedNodes(c.node && c.node !== "—" ? [c.node] : []);
     setMigrateRatioInput("");
+    setMigrateForce(false);
     setMigrateFormError(null);
     setMigrateOpen(true);
     setNodesLoading(true);
@@ -74,7 +76,7 @@ function ContainerDetail({ item, onBack, onRefetch }) {
     }
 
     let minImprovementRatio;
-    if (migrateRatioInput.trim() !== "") {
+    if (!migrateForce && migrateRatioInput.trim() !== "") {
       const parsed = Number(migrateRatioInput.trim());
       if (Number.isNaN(parsed)) {
         setMigrateFormError("최소 개선 비율은 숫자로 입력하세요.");
@@ -86,7 +88,7 @@ function ContainerDetail({ item, onBack, onRefetch }) {
     setMigrateFormError(null);
     setIsMigrating(true);
     try {
-      const response = await requestService.migrateRequest(c.requestId, nodes, minImprovementRatio);
+      const response = await requestService.migrateRequest(c.requestId, nodes, minImprovementRatio, migrateForce);
       const result = response.data?.data ?? response.data;
 
       if (result?.status === "migrated") {
@@ -257,15 +259,29 @@ function ContainerDetail({ item, onBack, onRefetch }) {
               </div>
             )}
           </FormField>
-          <FormField label="최소 개선 비율 (선택)" description="생략하면 config-server 기본값을 사용합니다.">
-            <Input
-              value={migrateRatioInput}
-              onChange={setMigrateRatioInput}
-              placeholder="0.2"
-              type="number"
+          <label style={{ display: "flex", alignItems: "center", gap: "var(--decs-space-xs)", cursor: isMigrating ? "default" : "pointer" }}>
+            <input
+              type="checkbox"
+              checked={migrateForce}
+              onChange={(event) => setMigrateForce(event.target.checked)}
               disabled={isMigrating}
             />
-          </FormField>
+            <span style={{ fontWeight: 600, color: "var(--decs-text-heading)" }}>필수로 마이그레이션</span>
+            <span style={{ color: "var(--decs-text-secondary)", fontSize: "var(--decs-fs-body-s)" }}>
+              개선 효과와 무관하게 선택한 노드로 옮깁니다.
+            </span>
+          </label>
+          {!migrateForce && (
+            <FormField label="최소 개선 비율 (선택)" description="생략하면 config-server 기본값을 사용합니다.">
+              <Input
+                value={migrateRatioInput}
+                onChange={setMigrateRatioInput}
+                placeholder="0.2"
+                type="number"
+                disabled={isMigrating}
+              />
+            </FormField>
+          )}
         </div>
       </Modal>
 

--- a/src/pages/decs-console/user/UserPortalApp.jsx
+++ b/src/pages/decs-console/user/UserPortalApp.jsx
@@ -21,7 +21,6 @@ function UserPortalApp() {
   const { user, logout } = useAuth();
   const { t, i18n } = useTranslation();
   const { server, servers, expiryDays, activities, gpuOptions, envOptions, groupOptions, error } = useDecsUserData();
-  const [submitError, setSubmitError] = React.useState(null);
   const userName = user?.name || user?.email || "사용자";
   const isAdmin = user?.role === "ADMIN";
 
@@ -55,17 +54,11 @@ function UserPortalApp() {
   ];
 
   async function submitRequest(form) {
-    setSubmitError(null);
-    try {
-      const response = await requestService.createRequest(toRequestPayload(form));
-      if (response.status !== 200 && response.status !== 201) {
-        throw new Error("신청에 실패했습니다.");
-      }
-      navigate("/user/requests");
-    } catch (error) {
-      setSubmitError(error.message || "신청에 실패했습니다.");
-      return false;
+    const response = await requestService.createRequest(toRequestPayload(form));
+    if (response.status !== 200 && response.status !== 201) {
+      throw new Error("신청에 실패했습니다.");
     }
+    navigate("/user/requests");
   }
 
   async function submitExtension({ requestId, expiresAt, reason }) {
@@ -94,7 +87,6 @@ function UserPortalApp() {
         navigationWidth={240}
       >
         {error ? <div style={{ marginBottom: "var(--decs-space-m)" }}><Flashbar items={[{ id: "decs-user-data", type: "warning", header: error, dismissible: false }]} /></div> : null}
-        {submitError ? <div style={{ marginBottom: "var(--decs-space-m)" }}><Flashbar items={[{ id: "decs-request-submit", type: "error", header: submitError, dismissible: false }]} /></div> : null}
         <Routes>
           <Route index element={<UserDashboard userName={userName} server={server} expiryDays={expiryDays} activities={activities ?? []} onRequest={() => navigate("/user/request")} onConnect={() => navigate("/user/container")} onExtend={() => navigate("/user/container", { state: { extend: true } })} onDetail={() => navigate("/user/container")} />} />
           <Route path="request" element={<RequestWizard onCancel={() => navigate("/user")} onDone={() => navigate("/user/requests")} gpuOptions={gpuOptions ?? []} envOptions={envOptions ?? []} groupOptions={groupOptions ?? []} onSubmit={submitRequest} />} />

--- a/src/services/requestService.js
+++ b/src/services/requestService.js
@@ -32,10 +32,11 @@ export const requestService = {
     }),
   getMyChangeRequests: () => apiClient.get("/api/requests/my/changes"),
 
-  migrateRequest: (requestId, nodes, minImprovementRatio) =>
+  migrateRequest: (requestId, nodes, minImprovementRatio, force) =>
     apiClient.post(`/api/admin/requests/${requestId}/migrate`, {
       nodes,
       ...(minImprovementRatio != null && { minImprovementRatio }),
+      ...(force && { force }),
     }, {
       // nginx/ingress 프록시 타임아웃(570s)보다 길게 잡아야 백엔드가 정상
       // 처리 중일 때 프론트가 먼저 타임아웃돼버리는 걸 막을 수 있다.


### PR DESCRIPTION
## Summary
- 신청 제출 409 등 에러 메시지가 스크롤 밖 배너에 가려 안 보이던 문제 수정 (RequestWizard 인라인 Alert로 이동)
- 공용 Modal 포커스 관리 버그 수정 — 텍스트 입력 시 한 글자마다 포커스가 뺏겨 끊기던 문제 (연장 사유 등 모든 모달에 영향)
- 사이드바 신청서 관리/변경 요청 관리에 대기중 건수 뱃지 추가
- Pod 마이그레이션 모달에 개선 비율 무시하고 강제 실행하는 옵션 추가 (백엔드: CSID-DGU/admin_be#456)

## Test plan
- [x] eslint 통과 (기존 경고만, 신규 에러 없음)
- [x] vite build 성공
- [ ] 배포 후 실제 신청 제출 409 케이스로 에러 메시지 노출 확인
- [ ] 연장 사유 모달에서 텍스트 정상 입력되는지 확인

Closes #102, Closes #103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pending request and change-request counts to administration navigation badges.
  * Added an optional force-migration setting to Pod migration workflows.
* **Bug Fixes**
  * Prevented dialog inputs from losing focus during parent re-renders.
  * Improved request submission error propagation for consistent handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->