### PR TITLE
feat: 대시보드 오류 감지 확장 + 클릭 시 사유 확인

### DIFF
--- a/src/hooks/useDecsAdminData.js
+++ b/src/hooks/useDecsAdminData.js
@@ -59,8 +59,16 @@ export function useDecsAdminData() {
           const statusResult = provisioningStatuses[index];
           const detail = result.status === "fulfilled" ? result.value?.data?.data ?? result.value?.data : null;
           const provisioning = statusResult.status === "fulfilled" ? statusResult.value?.data : null;
-          if (container.podName && !detail && (!provisioning || provisioning.stage === "unknown")) hasError = true;
-          return mapAdminContainer({ ...container, podDetail: detail, status: detail?.status ?? provisioning?.stage });
+          // Pod 상세도 프로비저닝 상태도 못 가져오면 그 컨테이너가 실제로 정상인지 전혀 알 수
+          // 없다는 뜻이라, "확인 불가"를 조용히 pending으로 묻지 않고 오류로 명시한다.
+          const couldNotResolveStatus = container.podName && !detail && (!provisioning || provisioning.stage === "unknown");
+          if (couldNotResolveStatus) hasError = true;
+          // effectiveStatus는 phase(예: Running)보다 컨테이너 실제 waiting/terminated 사유
+          // (CrashLoopBackOff 등)를 우선한다 — phase만 보면 반복 재시작 중인 컨테이너를 놓친다.
+          const status = couldNotResolveStatus
+              ? "lookup-failed"
+              : detail?.effectiveStatus ?? detail?.status ?? provisioning?.stage;
+          return mapAdminContainer({ ...container, podDetail: detail, status });
         }));
       } else {
         hasError = true;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -9,5 +9,5 @@
   "shell": {
     "adminTitle": "DECS Admin Console", "userTitle": "DGU GPU Portal", "dashboard": "Dashboard", "containers": "Containers", "myContainer": "My container", "gpuRequest": "GPU request", "requests": "Requests", "requestManagement": "Request management", "changeRequests": "Change requests", "changeManagement": "Change management", "users": "Users", "system": "System", "monitoring": "Monitoring", "resourceMonitoring": "Resource monitoring", "images": "Images", "templates": "Message templates", "account": "Account"
   },
-  "status": { "running": "Running", "provisioning": "Provisioning", "error": "Error", "stopped": "Stopped", "pending": "Pending approval", "denied": "Denied", "unknown": "Unknown", "migrating": "Migrating", "deleted": "Deleted" }
+  "status": { "running": "Running", "provisioning": "Provisioning", "error": "Error", "stopped": "Stopped", "pending": "Pending approval", "denied": "Denied", "unknown": "Unknown", "migrating": "Migrating", "deleted": "Deleted", "crash-loop": "Crash looping", "image-pull-error": "Image pull failed", "oom-killed": "Killed (OOM)", "evicted": "Evicted", "lookup-failed": "Status unavailable" }
 }

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -9,5 +9,5 @@
   "shell": {
     "adminTitle": "DECS 관리자 콘솔", "userTitle": "DGU GPU 포털", "dashboard": "대시보드", "containers": "컨테이너 관리", "myContainer": "내 컨테이너", "gpuRequest": "GPU 신청", "requests": "신청 현황", "requestManagement": "신청서 관리", "changeRequests": "변경 요청 현황", "changeManagement": "변경 요청 관리", "users": "사용자 관리", "system": "시스템", "monitoring": "모니터링", "resourceMonitoring": "리소스 모니터링", "images": "이미지", "templates": "메시지 템플릿", "account": "계정 설정"
   },
-  "status": { "running": "실행 중", "provisioning": "프로비저닝 중", "error": "오류", "stopped": "종료", "pending": "승인 대기", "denied": "거절됨", "unknown": "알 수 없음", "migrating": "마이그레이션 중", "deleted": "삭제됨" }
+  "status": { "running": "실행 중", "provisioning": "프로비저닝 중", "error": "오류", "stopped": "종료", "pending": "승인 대기", "denied": "거절됨", "unknown": "알 수 없음", "migrating": "마이그레이션 중", "deleted": "삭제됨", "crash-loop": "반복 재시작 중", "image-pull-error": "이미지 가져오기 실패", "oom-killed": "메모리 초과로 종료됨", "evicted": "축출됨", "lookup-failed": "상태 확인 불가" }
 }

--- a/src/pages/decs-console/admin/AdminConsoleApp.jsx
+++ b/src/pages/decs-console/admin/AdminConsoleApp.jsx
@@ -72,7 +72,7 @@ function AdminConsoleApp() {
       >
         {error && (location.pathname === "/admin" || location.pathname.startsWith("/admin/containers")) ? <div style={{ marginBottom: "var(--decs-space-m)" }}><Flashbar items={[{ id: "decs-admin-data", type: "warning", header: error, dismissible: false }]} /></div> : null}
         <Routes>
-          <Route index element={<AdminDashboard onOpenContainers={() => navigate("/admin/containers")} onOpenDetail={(c) => navigate(`/admin/containers/${c.id}`)} containers={containers ?? []} users={users ?? []} />} />
+          <Route index element={<AdminDashboard onOpenContainers={() => navigate("/admin/containers")} onOpenErrorContainers={() => navigate("/admin/containers", { state: { statusFilter: "error" } })} onOpenDetail={(c) => navigate(`/admin/containers/${c.id}`)} containers={containers ?? []} users={users ?? []} />} />
           <Route path="containers" element={<ContainerManagement onOpenDetail={(c) => navigate(`/admin/containers/${c.id}`)} containers={containers ?? []} />} />
           <Route path="containers/:containerId" element={<ContainerDetailRoute containers={containers ?? []} onRefetch={refetch} />} />
           <Route path="requests" element={<RequestManagementPage />} />

--- a/src/pages/decs-console/admin/AdminDashboard.jsx
+++ b/src/pages/decs-console/admin/AdminDashboard.jsx
@@ -1,9 +1,16 @@
 // AdminDashboard — 전체 상태 즉시 파악 (GPU 사용률 · 컨테이너 상태 · 만료 예정 · 최근 활동)
 import { Container, Header, StatusIndicator, Badge, Button, Table, Alert } from "../../../design-system";
 
-function StatCard({ label, value, sub, accent }) {
+function StatCard({ label, value, sub, accent, onClick }) {
   return (
-    <div style={{ flex: 1, background: "var(--decs-surface-container)", border: "1px solid var(--decs-border-container)", borderRadius: "var(--decs-radius-container)", boxShadow: "var(--decs-shadow-container)", padding: "var(--decs-space-l)" }}>
+    <div
+      onClick={onClick}
+      style={{
+        flex: 1, background: "var(--decs-surface-container)", border: "1px solid var(--decs-border-container)",
+        borderRadius: "var(--decs-radius-container)", boxShadow: "var(--decs-shadow-container)", padding: "var(--decs-space-l)",
+        cursor: onClick ? "pointer" : "default",
+      }}
+    >
       <div style={{ fontSize: "var(--decs-fs-body-s)", color: "var(--decs-text-inactive)" }}>{label}</div>
       <div style={{ fontSize: "var(--decs-fs-heading-xl)", fontWeight: 700, color: accent || "var(--decs-text-heading)", marginTop: 4, lineHeight: 1.1 }}>{value}</div>
       {sub ? <div style={{ fontSize: "var(--decs-fs-body-s)", color: "var(--decs-text-secondary)", marginTop: 4 }}>{sub}</div> : null}
@@ -11,7 +18,7 @@ function StatCard({ label, value, sub, accent }) {
   );
 }
 
-function AdminDashboard({ onOpenContainers, onOpenDetail, containers = [], users = [] }) {
+function AdminDashboard({ onOpenContainers, onOpenErrorContainers, onOpenDetail, containers = [], users = [] }) {
   const running = containers.filter((c) => c.status === "success").length;
   const errored = containers.filter((c) => c.status === "error").length;
   const expiring = containers.filter((c) => c.status !== "stopped" && c.expires !== "—" && c.expires <= "2026-07-11").length;
@@ -27,15 +34,15 @@ function AdminDashboard({ onOpenContainers, onOpenDetail, containers = [], users
       <Header variant="h1" description="클러스터 자원과 컨테이너 상태를 한눈에 확인합니다">대시보드</Header>
 
       {errored > 0 ? (
-        <Alert type="error" header={`컨테이너 ${errored}건에 오류가 있습니다`} action={<Button variant="normal" onClick={onOpenContainers}>확인</Button>}>
+        <Alert type="error" header={`컨테이너 ${errored}건에 오류가 있습니다`} action={<Button variant="normal" onClick={onOpenErrorContainers}>확인</Button>}>
           desired-state와 observed-state 불일치가 감지되었습니다. 상세에서 이벤트 로그를 확인하세요.
         </Alert>
       ) : null}
 
       <div style={{ display: "flex", gap: "var(--decs-space-m)" }}>
-        <StatCard label="실행 중 컨테이너" value={running} sub={`전체 ${containers.length}건`} />
-        <StatCard label="오류" value={errored} sub="즉시 조치 필요" accent="var(--decs-status-error)" />
-        <StatCard label="만료 임박 (3일)" value={expiring} sub="연장 안내 대상" accent="var(--decs-status-warning)" />
+        <StatCard label="실행 중 컨테이너" value={running} sub={`전체 ${containers.length}건`} onClick={onOpenContainers} />
+        <StatCard label="오류" value={errored} sub="즉시 조치 필요" accent="var(--decs-status-error)" onClick={onOpenErrorContainers} />
+        <StatCard label="만료 임박 (3일)" value={expiring} sub="연장 안내 대상" accent="var(--decs-status-warning)" onClick={onOpenContainers} />
         <StatCard label="등록 사용자" value={users.length} sub="활성 세션 5" />
       </div>
 

--- a/src/pages/decs-console/admin/ContainerDetail.jsx
+++ b/src/pages/decs-console/admin/ContainerDetail.jsx
@@ -144,6 +144,7 @@ function ContainerDetail({ item, onBack, onRefetch }) {
       <Container header={<Header variant="h2">스펙</Header>}>
         <KeyValuePairs columns={3} items={[
           { label: "상태", value: <StatusIndicator type={c.status}>{c.label}</StatusIndicator> },
+          ...(c.statusReason ? [{ label: "오류 사유", value: c.statusReason }] : []),
           { label: "리소스 그룹", value: c.gpu },
           { label: "노드", value: c.node },
           { label: "이미지", value: c.image },

--- a/src/pages/decs-console/admin/ContainerManagement.jsx
+++ b/src/pages/decs-console/admin/ContainerManagement.jsx
@@ -1,13 +1,16 @@
 // ContainerManagement — Table + 검색/필터 + 행 상세 + 무한 스크롤
 import React from "react";
+import { useLocation } from "react-router-dom";
 import { Table, Header, Container, StatusIndicator, Badge, Button, Input, Select } from "../../../design-system";
 
 const BATCH_SIZE = 10;
 
 function ContainerManagement({ onOpenDetail, containers = [] }) {
+  const location = useLocation();
   const all = containers;
   const [q, setQ] = React.useState("");
-  const [statusFilter, setStatusFilter] = React.useState("all");
+  // 대시보드 "오류" 카드/알림에서 넘어올 때 location.state로 초기 필터를 지정할 수 있게 한다.
+  const [statusFilter, setStatusFilter] = React.useState(location.state?.statusFilter ?? "all");
   const [sort, setSort] = React.useState({ col: null, desc: false });
   const [visibleCount, setVisibleCount] = React.useState(BATCH_SIZE);
   const sentinelRef = React.useRef(null);
@@ -76,7 +79,15 @@ function ContainerManagement({ onOpenDetail, containers = [] }) {
             { id: "user", header: "사용자", sortingField: "user", cell: (c) => c.user },
             { id: "gpu", header: "리소스 그룹", cell: (c) => <Badge color="brand">{c.gpu}</Badge> },
             { id: "node", header: "노드", sortingField: "node", cell: (c) => c.node },
-            { id: "status", header: "상태", cell: (c) => <StatusIndicator type={c.status}>{c.label}</StatusIndicator> },
+            {
+              id: "status",
+              header: "상태",
+              cell: (c) => (
+                <span title={c.statusReason ?? undefined}>
+                  <StatusIndicator type={c.status}>{c.label}</StatusIndicator>
+                </span>
+              ),
+            },
             { id: "expires", header: "만료", sortingField: "expires", cell: (c) => <span style={{ color: "var(--decs-text-secondary)" }}>{c.expires}</span> },
             { id: "actions", header: "", width: 90, cell: (c) => <Button variant="normal" onClick={() => onOpenDetail(c)}>상세</Button> },
           ]}

--- a/src/utils/decsMapper.js
+++ b/src/utils/decsMapper.js
@@ -7,7 +7,11 @@ const STATUS_MAP = {
   ContainerCreating: { type: "in-progress", key: "provisioning" },
   Failed: { type: "error", key: "error" },
   Error: { type: "error", key: "error" },
-  CrashLoopBackOff: { type: "error", key: "error" },
+  CrashLoopBackOff: { type: "error", key: "crash-loop" },
+  ImagePullBackOff: { type: "error", key: "image-pull-error" },
+  ErrImagePull: { type: "error", key: "image-pull-error" },
+  OOMKilled: { type: "error", key: "oom-killed" },
+  Evicted: { type: "error", key: "evicted" },
   Succeeded: { type: "stopped", key: "stopped" },
   Completed: { type: "stopped", key: "stopped" },
   ready: { type: "success", key: "running" },
@@ -27,6 +31,7 @@ const STATUS_MAP = {
   DENIED: { type: "error", key: "denied" },
   MIGRATING: { type: "in-progress", key: "migrating" },
   DELETED: { type: "stopped", key: "deleted" },
+  "lookup-failed": { type: "error", key: "lookup-failed" },
 };
 
 function formatDate(dateStr) {
@@ -98,6 +103,7 @@ export function mapAdminContainer(dto) {
     podContainers: detail.containers ?? [],
     status: status.type,
     label: status.label,
+    statusReason: detail.reason ?? null,
     expires: formatDate(dto.expiresAt),
     image: image || "—",
   };


### PR DESCRIPTION
## Summary
- CrashLoopBackOff/ImagePullBackOff/ErrImagePull/OOMKilled/Evicted를 오류로 인식 (백엔드 effectiveStatus 활용, admin_be#460 선반영 필요)
- Pod 상세/프로비저닝 조회 자체 실패도 "상태 확인 불가" 오류로 명시
- 대시보드 오류 카드/알림 클릭 시 컨테이너 관리로 오류 필터 적용된 채 이동
- 목록/상세 화면에 오류 사유(reason) 노출

## Test plan
- [x] eslint 통과 (기존 경고만)
- [x] vite build 성공
- [ ] 배포 후 실제 CrashLoopBackOff 컨테이너로 오류 카운트/클릭 이동/사유 표시 확인

Closes #105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear labels for container issues, including crash loops, image pull failures, memory exhaustion, eviction, and status lookup failures.
  * Dashboard status cards and alerts now open filtered container lists for active or error states.
  * Container details display the reason for an error when available.

* **Bug Fixes**
  * Container statuses now accurately reflect reported runtime states.
  * Unresolved container statuses are marked as errors instead of appearing pending.
  * Error reasons are available as tooltips in container lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->