### PR TITLE
feat: 컨테이너 상세 로그/이벤트 탭 실 데이터 연동

### DIFF
--- a/src/pages/decs-console/admin/ContainerDetail.jsx
+++ b/src/pages/decs-console/admin/ContainerDetail.jsx
@@ -1,5 +1,5 @@
 // ContainerDetail — 섹션(Container+Header) · 스펙(KeyValuePairs) · 탭(개요/로그/이벤트)
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Container, Header, KeyValuePairs, Tabs, StatusIndicator, BreadcrumbGroup,
   Button, Modal, Alert, FormField, Input,
@@ -7,6 +7,7 @@ import {
 import { requestService } from "../../../services/requestService";
 import userService from "../../../services/userService";
 import { nodeService } from "../../../services/nodeService";
+import { podService } from "../../../services/podService";
 
 function ContainerDetail({ item, onBack, onRefetch }) {
   const c = item;
@@ -23,6 +24,43 @@ function ContainerDetail({ item, onBack, onRefetch }) {
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState(null);
+
+  const [logsText, setLogsText] = useState(null);
+  const [logsLoading, setLogsLoading] = useState(true);
+  const [logsError, setLogsError] = useState(null);
+  const [podEvents, setPodEvents] = useState(null);
+  const [eventsLoading, setEventsLoading] = useState(true);
+  const [eventsError, setEventsError] = useState(null);
+
+  useEffect(() => {
+    if (!c?.podName) {
+      setLogsLoading(false);
+      setEventsLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLogsLoading(true);
+    setEventsLoading(true);
+    podService.getPodLogs(c.podName).then((res) => {
+      if (cancelled) return;
+      setLogsText(res.data?.data?.logs ?? "");
+      setLogsError(null);
+    }).catch(() => {
+      if (!cancelled) setLogsError("로그를 불러오지 못했습니다.");
+    }).finally(() => {
+      if (!cancelled) setLogsLoading(false);
+    });
+    podService.getPodEvents(c.podName).then((res) => {
+      if (cancelled) return;
+      setPodEvents(res.data?.data ?? []);
+      setEventsError(null);
+    }).catch(() => {
+      if (!cancelled) setEventsError("이벤트를 불러오지 못했습니다.");
+    }).finally(() => {
+      if (!cancelled) setEventsLoading(false);
+    });
+    return () => { cancelled = true; };
+  }, [c?.podName]);
 
   if (!c) {
     return (
@@ -159,15 +197,55 @@ function ContainerDetail({ item, onBack, onRefetch }) {
     </div>
   );
 
-  const logs = (
+  const logs = logsLoading ? (
+    <div style={{ color: "var(--decs-text-secondary)", fontSize: "var(--decs-fs-body-s)", padding: "16px 0", textAlign: "center" }}>
+      로그를 불러오는 중...
+    </div>
+  ) : logsError ? (
+    <Alert type="error">{logsError}</Alert>
+  ) : !logsText ? (
     <div style={{ color: "var(--decs-text-secondary)", fontSize: "var(--decs-fs-body-s)", padding: "16px 0", textAlign: "center" }}>
       표시할 로그 데이터가 없습니다.
     </div>
+  ) : (
+    <pre style={{
+      margin: 0, padding: "var(--decs-space-m)", maxHeight: 480, overflow: "auto",
+      background: "var(--decs-surface-sunken)", borderRadius: "var(--decs-radius-container)",
+      fontFamily: "var(--decs-font-mono, monospace)", fontSize: "var(--decs-fs-body-s)",
+      color: "var(--decs-text-body)", whiteSpace: "pre-wrap", wordBreak: "break-all",
+    }}>
+      {logsText}
+    </pre>
   );
 
-  const events = (
+  const events = eventsLoading ? (
+    <div style={{ color: "var(--decs-text-secondary)", fontSize: "var(--decs-fs-body-s)", padding: "16px 0", textAlign: "center" }}>
+      이벤트를 불러오는 중...
+    </div>
+  ) : eventsError ? (
+    <Alert type="error">{eventsError}</Alert>
+  ) : !podEvents || podEvents.length === 0 ? (
     <div style={{ color: "var(--decs-text-secondary)", fontSize: "var(--decs-fs-body-s)", padding: "16px 0", textAlign: "center" }}>
       표시할 이벤트 데이터가 없습니다.
+    </div>
+  ) : (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-s)" }}>
+      {podEvents.map((ev, idx) => (
+        <div
+          key={idx}
+          style={{
+            display: "flex", gap: "var(--decs-space-s)", alignItems: "flex-start",
+            padding: "var(--decs-space-s) var(--decs-space-m)", borderRadius: "var(--decs-radius-container)",
+            background: "var(--decs-surface-sunken)",
+          }}
+        >
+          <StatusIndicator type={ev.type === "Warning" ? "warning" : "success"}>{ev.reason}</StatusIndicator>
+          <div style={{ flex: 1, fontSize: "var(--decs-fs-body-s)", color: "var(--decs-text-body)" }}>{ev.message}</div>
+          <div style={{ fontSize: "var(--decs-fs-body-s)", color: "var(--decs-text-secondary)", whiteSpace: "nowrap" }}>
+            {ev.count > 1 ? `${ev.count}회 · ` : ""}{ev.lastTimestamp}
+          </div>
+        </div>
+      ))}
     </div>
   );
 

--- a/src/services/podService.js
+++ b/src/services/podService.js
@@ -3,6 +3,9 @@ import apiClient from "./api.js";
 export const podService = {
   getAllPods: () => apiClient.get("/api/admin/pods"),
   getPod: (podName) => apiClient.get(`/api/admin/pods/${encodeURIComponent(podName)}`),
+  getPodLogs: (podName, container) =>
+    apiClient.get(`/api/admin/pods/${encodeURIComponent(podName)}/logs`, container ? { container } : undefined),
+  getPodEvents: (podName) => apiClient.get(`/api/admin/pods/${encodeURIComponent(podName)}/events`),
   getProvisioningStatus: (username) => apiClient.get(`/pod-status/pods/${encodeURIComponent(username)}/status`),
   getActiveContainers: () => apiClient.get("/api/admin/requests/containers"),
   getUsage: () => apiClient.get("/api/admin/requests/usage"),


### PR DESCRIPTION
## Summary
- 컨테이너 상세 로그/이벤트 탭을 새 백엔드 API(admin_be#462)에 연결
- Pod 진입 시 로그(최근 500줄)와 이벤트(최신 50건)를 병렬로 조회, 각각 로딩/에러/빈 상태 처리

## Test plan
- [x] eslint 통과 (기존 경고만)
- [x] vite build 성공
- [ ] 배포 후 실제 컨테이너 상세에서 로그/이벤트 표시 확인 (백엔드 admin_be#462 이미 배포됨)

Closes #109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pod log viewing in the container detail page.
  * Added pod event viewing with loading, error, empty, and populated states.
  * Logs can be retrieved for a specific container when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->