### PR TITLE
fix: 관리자 UX 정리 — 드롭다운 잘림/새로고침 일관성/대시보드 개선

### DIFF
--- a/src/design-system/components/forms/Select.jsx
+++ b/src/design-system/components/forms/Select.jsx
@@ -1,20 +1,47 @@
 import React from "react";
+import { createPortal } from "react-dom";
 import { Icon } from "../icons/Icon.jsx";
 
 /**
  * Select — dropdown single-select matching Cloudscape trigger + popover list.
  * options: [{ value, label, description?, disabled? }]
+ *
+ * 옵션 목록은 document.body에 포털로 그린다 — Container 등 카드형 컴포넌트가 둥근
+ * 모서리를 위해 overflow:hidden을 쓰는데, 그 안에 이 목록을 그대로 두면 절대위치
+ * 팝업이 카드 경계에서 잘려버린다(예: 사용자 관리의 역할/상태 필터 드롭다운).
  */
 export function Select({ options = [], selectedValue, onChange, placeholder = "선택하세요", disabled, invalid, id, ariaLabel, style }) {
   const [open, setOpen] = React.useState(false);
+  const [menuRect, setMenuRect] = React.useState(null);
   const ref = React.useRef(null);
+  const menuRef = React.useRef(null);
   const selected = options.find((o) => o.value === selectedValue);
 
   React.useEffect(() => {
-    function onDoc(e) { if (ref.current && !ref.current.contains(e.target)) setOpen(false); }
+    function onDoc(e) {
+      if (ref.current && ref.current.contains(e.target)) return;
+      if (menuRef.current && menuRef.current.contains(e.target)) return;
+      setOpen(false);
+    }
     document.addEventListener("mousedown", onDoc);
     return () => document.removeEventListener("mousedown", onDoc);
   }, []);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const updateRect = () => {
+      const rect = ref.current?.getBoundingClientRect();
+      if (rect) setMenuRect(rect);
+    };
+    updateRect();
+    // 스크롤/리사이즈 중엔 트리거 위치가 바뀌므로 팝업 위치도 같이 갱신한다.
+    window.addEventListener("scroll", updateRect, true);
+    window.addEventListener("resize", updateRect);
+    return () => {
+      window.removeEventListener("scroll", updateRect, true);
+      window.removeEventListener("resize", updateRect);
+    };
+  }, [open]);
 
   const borderColor = invalid ? "var(--decs-status-error)" : open ? "var(--decs-border-focus)" : "var(--decs-border-input)";
 
@@ -42,9 +69,9 @@ export function Select({ options = [], selectedValue, onChange, placeholder = "�
         <span title={selected ? selected.label : placeholder} style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{selected ? selected.label : placeholder}</span>
         <Icon name="chevron-down" size={16} color="var(--decs-text-secondary)" />
       </button>
-      {open ? (
-        <div role="listbox" style={{
-          position: "absolute", top: "calc(100% + 4px)", left: 0, right: 0, zIndex: 50,
+      {open && menuRect ? createPortal(
+        <div ref={menuRef} role="listbox" style={{
+          position: "fixed", top: menuRect.bottom + 4, left: menuRect.left, width: menuRect.width, zIndex: 1000,
           background: "var(--decs-white)", border: "1px solid var(--decs-border-divider)",
           borderRadius: "var(--decs-radius-item)", boxShadow: "var(--decs-shadow-dropdown)",
           padding: "var(--decs-space-xxs)", maxHeight: "260px", overflowY: "auto",
@@ -76,7 +103,8 @@ export function Select({ options = [], selectedValue, onChange, placeholder = "�
               </button>
             );
           })}
-        </div>
+        </div>,
+        document.body
       ) : null}
     </div>
   );

--- a/src/hooks/useDecsUserData.js
+++ b/src/hooks/useDecsUserData.js
@@ -31,6 +31,17 @@ function mapActivity(request) {
   return {
     label: createdAt ? String(createdAt).slice(0, 10) : "—",
     value: `서버 신청 · ${getStatusLabel(request.status)}`,
+    requestId: request.requestId ?? request.request_id,
+    status: request.status,
+    statusLabel: getStatusLabel(request.status),
+    createdAt,
+    resourceGroupName: request.resourceGroup?.resourceGroupName ?? request.resource_group?.resource_group_name,
+    serverName: request.resourceGroup?.serverName ?? request.resource_group?.server_name,
+    imageName: request.imageName ?? request.image_name,
+    imageVersion: request.imageVersion ?? request.image_version,
+    usagePurpose: request.usagePurpose ?? request.usage_purpose,
+    expiresAt: request.expiresAt ?? request.expires_at,
+    comment: request.comment,
   };
 }
 

--- a/src/pages/admin/ChangeRequestManagementPage.jsx
+++ b/src/pages/admin/ChangeRequestManagementPage.jsx
@@ -37,12 +37,12 @@ const ChangeRequestManagementPage = () => {
   const [, setAllRequests] = useState([]);
   const [selectedChangeRequest, setSelectedChangeRequest] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [lastUpdated, setLastUpdated] = useState(null);
   const [filter, setFilter] = useState("ALL"); // ALL, PENDING, FULFILLED, DENIED
   const [alert, setAlert] = useState(null);
   const [processingChangeRequestId, setProcessingChangeRequestId] = useState(null);
 
-  useEffect(() => {
-    const fetchData = async () => {
+  const fetchData = async () => {
       setIsLoading(true);
       setAlert(null);
 
@@ -93,6 +93,7 @@ const ChangeRequestManagementPage = () => {
 
           setChangeRequests(transformedChangeRequests);
           setAllRequests(allRequestsArray);
+          setLastUpdated(new Date());
         } else {
           setAlert({
             type: "error",
@@ -110,8 +111,9 @@ const ChangeRequestManagementPage = () => {
       } finally {
         setIsLoading(false);
       }
-    };
+  };
 
+  useEffect(() => {
     fetchData();
   }, []);
 
@@ -436,6 +438,16 @@ const ChangeRequestManagementPage = () => {
       <Header
         variant="h1"
         description="사용자들의 서버 변경 요청을 검토하고 승인/거절할 수 있습니다."
+        actions={
+          <div style={{ display: "flex", alignItems: "center", gap: "var(--decs-space-s)" }}>
+            {lastUpdated ? (
+              <span style={{ fontSize: "var(--decs-fs-body-s)", color: "var(--decs-text-secondary)" }}>
+                {lastUpdated.toLocaleTimeString("ko-KR")} 기준
+              </span>
+            ) : null}
+            <Button iconName="arrow-path" loading={isLoading} onClick={fetchData}>새로고침</Button>
+          </div>
+        }
       >
         변경 요청 관리
       </Header>

--- a/src/pages/admin/ImageManagementPage.jsx
+++ b/src/pages/admin/ImageManagementPage.jsx
@@ -14,6 +14,7 @@ import {
 const ImageManagementPage = () => {
   const [images, setImages] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState(null);
   const [alert, setAlert] = useState(null);
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [formData, setFormData] = useState({
@@ -33,6 +34,7 @@ const ImageManagementPage = () => {
       const result = await getImages();
       if (result.success) {
         setImages(result.data);
+        setLastUpdated(new Date());
       } else {
         setAlert({
           type: 'error',
@@ -146,13 +148,21 @@ const ImageManagementPage = () => {
         variant="h1"
         description="컨테이너 생성에 사용할 도커 이미지를 관리합니다."
         actions={
-          <Button
-            variant={showCreateForm ? 'normal' : 'primary'}
-            iconName={showCreateForm ? undefined : 'plus'}
-            onClick={() => setShowCreateForm(!showCreateForm)}
-          >
-            {showCreateForm ? '취소' : '새 이미지 생성'}
-          </Button>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--decs-space-s)' }}>
+            {lastUpdated ? (
+              <span style={{ fontSize: 'var(--decs-fs-body-s)', color: 'var(--decs-text-secondary)' }}>
+                {lastUpdated.toLocaleTimeString('ko-KR')} 기준
+              </span>
+            ) : null}
+            <Button iconName="arrow-path" loading={loading} onClick={fetchImages}>새로고침</Button>
+            <Button
+              variant={showCreateForm ? 'normal' : 'primary'}
+              iconName={showCreateForm ? undefined : 'plus'}
+              onClick={() => setShowCreateForm(!showCreateForm)}
+            >
+              {showCreateForm ? '취소' : '새 이미지 생성'}
+            </Button>
+          </div>
         }
       >
         이미지 관리

--- a/src/pages/admin/RequestManagementPage.jsx
+++ b/src/pages/admin/RequestManagementPage.jsx
@@ -45,6 +45,7 @@ const RequestManagementPage = () => {
   const [requests, setRequests] = useState([]);
   const [selectedRequest, setSelectedRequest] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [lastUpdated, setLastUpdated] = useState(null);
   const [filter, setFilter] = useState("PENDING"); // PENDING, FULFILLED, DENIED, DELETED
   const [period, setPeriod] = useState("3M"); // 1M, 3M, 6M, ALL
   const [visibleCount, setVisibleCount] = useState(PAGE_BATCH_SIZE);
@@ -86,40 +87,41 @@ const RequestManagementPage = () => {
     };
   }, [provisioningTargetUsername]);
 
-  useEffect(() => {
-    const fetchRequests = async () => {
-      setIsLoading(true);
-      setAlert(null);
+  const fetchRequests = async () => {
+    setIsLoading(true);
+    setAlert(null);
 
-      try {
-        const response = await requestService.getAllRequests();
+    try {
+      const response = await requestService.getAllRequests();
 
-        if (response.status === 200) {
-          // API 응답 데이터를 기존 UI에 맞게 변환
-          // response.data는 서버 응답이고, response.data.data가 실제 배열
-          const requestsArray = response.data?.data ?? [];
-          const transformedRequests = requestsArray.map(mapRequestDtoToUiModel);
+      if (response.status === 200) {
+        // API 응답 데이터를 기존 UI에 맞게 변환
+        // response.data는 서버 응답이고, response.data.data가 실제 배열
+        const requestsArray = response.data?.data ?? [];
+        const transformedRequests = requestsArray.map(mapRequestDtoToUiModel);
 
-          setRequests(transformedRequests);
-        } else {
-          setAlert({
-            type: "error",
-            message:
-              "신청서 목록을 불러올 수 없습니다. 서버 상태를 확인하시거나 관리자에게 문의해주세요.",
-          });
-        }
-      } catch (error) {
-        console.error("Failed to fetch requests:", error);
+        setRequests(transformedRequests);
+        setLastUpdated(new Date());
+      } else {
         setAlert({
           type: "error",
           message:
-            "신청서 목록 로딩 중 네트워크 오류가 발생했습니다. 인터넷 연결을 확인하시고 페이지를 새로고침해주세요.",
+            "신청서 목록을 불러올 수 없습니다. 서버 상태를 확인하시거나 관리자에게 문의해주세요.",
         });
-      } finally {
-        setIsLoading(false);
       }
-    };
+    } catch (error) {
+      console.error("Failed to fetch requests:", error);
+      setAlert({
+        type: "error",
+        message:
+          "신청서 목록 로딩 중 네트워크 오류가 발생했습니다. 인터넷 연결을 확인하시고 페이지를 새로고침해주세요.",
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
+  useEffect(() => {
     fetchRequests();
   }, []);
 
@@ -418,6 +420,16 @@ const RequestManagementPage = () => {
       <Header
         variant="h1"
         description="사용자들의 서버 사용 신청서를 검토하고 승인/거절할 수 있습니다."
+        actions={
+          <div style={{ display: "flex", alignItems: "center", gap: "var(--decs-space-s)" }}>
+            {lastUpdated ? (
+              <span style={{ fontSize: "var(--decs-fs-body-s)", color: "var(--decs-text-secondary)" }}>
+                {lastUpdated.toLocaleTimeString("ko-KR")} 기준
+              </span>
+            ) : null}
+            <Button iconName="arrow-path" loading={isLoading} onClick={fetchRequests}>새로고침</Button>
+          </div>
+        }
       >
         신청서 관리
       </Header>

--- a/src/pages/admin/UserManagementPage.jsx
+++ b/src/pages/admin/UserManagementPage.jsx
@@ -18,6 +18,7 @@ import {
 const UserManagementPage = () => {
   const [users, setUsers] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [lastUpdated, setLastUpdated] = useState(null);
   const [alert, setAlert] = useState(null);
   const [searchTerm, setSearchTerm] = useState("");
   const [filterRole, setFilterRole] = useState("ALL");
@@ -27,17 +28,12 @@ const UserManagementPage = () => {
   const loadUsers = async () => {
     try {
       setLoading(true);
-      console.log("사용자 목록 로드 시작...");
 
       const response = await userService.getAllUsers();
-      console.log("받은 응답:", response);
 
       if (response.status === 200) {
         setUsers(response.data.data || []);
-        setAlert({
-          type: "success",
-          message: "사용자 목록을 성공적으로 불러왔습니다.",
-        });
+        setLastUpdated(new Date());
       } else {
         setAlert({
           type: "error",
@@ -224,9 +220,16 @@ const UserManagementPage = () => {
         variant="h1"
         description="등록된 사용자들을 관리하고 권한을 설정할 수 있습니다."
         actions={
-          <Button iconName="arrow-path" loading={loading} onClick={loadUsers}>
-            새로고침
-          </Button>
+          <div style={{ display: "flex", alignItems: "center", gap: "var(--decs-space-s)" }}>
+            {lastUpdated ? (
+              <span style={{ fontSize: "var(--decs-fs-body-s)", color: "var(--decs-text-secondary)" }}>
+                {lastUpdated.toLocaleTimeString("ko-KR")} 기준
+              </span>
+            ) : null}
+            <Button iconName="arrow-path" loading={loading} onClick={loadUsers}>
+              새로고침
+            </Button>
+          </div>
         }
       >
         사용자 관리

--- a/src/pages/decs-console/admin/AdminDashboard.jsx
+++ b/src/pages/decs-console/admin/AdminDashboard.jsx
@@ -5,6 +5,35 @@ import { monitoringService } from "../../../services/grafanaService";
 
 const GPU_METRICS_REFRESH_MS = 30_000;
 
+function utilBadgeColor(util) {
+  if (util >= 80) return "red";
+  if (util >= 50) return "amber"; // 디자인 시스템 Badge는 "yellow"가 아니라 "amber"를 지원한다
+  return "green";
+}
+
+function GpuUtilRow({ server }) {
+  const util = server.gpuUtil ?? 0;
+  return (
+    <div style={{
+      border: "1px solid var(--decs-border-container)", borderRadius: "var(--decs-radius-item)",
+      background: "var(--decs-surface-sunken)", padding: "var(--decs-space-s) var(--decs-space-m)",
+    }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "var(--decs-space-xxs)" }}>
+        <span style={{ fontSize: "var(--decs-fs-body-s)", fontWeight: 700, color: "var(--decs-text-heading)", letterSpacing: "0.02em", textTransform: "uppercase" }}>
+          {server.hostname}
+        </span>
+        <div style={{ display: "flex", alignItems: "center", gap: "var(--decs-space-xs)" }}>
+          <Badge color={utilBadgeColor(util)}>{util}%</Badge>
+          <span style={{ fontSize: "var(--decs-fs-body-s)", color: "var(--decs-text-secondary)" }}>GPU {server.gpuCount}개</span>
+        </div>
+      </div>
+      {/* ProgressBar의 status="error"는 진행률이 아니라 "완료(실패)" 취급이라 바 자체가 안
+          그려진다 — 사용률 게이지 용도로는 항상 in-progress로 그리고, 색 구분은 위 Badge로 한다. */}
+      <ProgressBar value={util} status="in-progress" />
+    </div>
+  );
+}
+
 function GpuUtilPanel() {
   const [servers, setServers] = useState(null);
   const [error, setError] = useState(null);
@@ -39,24 +68,17 @@ function GpuUtilPanel() {
     return <div style={{ color: "var(--decs-text-secondary)", fontSize: "var(--decs-fs-body-s)", padding: "16px 0", textAlign: "center" }}>GPU 데이터를 수신하지 못했습니다.</div>;
   }
 
+  const avgUtil = Math.round(servers.reduce((sum, s) => sum + (s.gpuUtil ?? 0), 0) / servers.length);
+
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-m)" }}>
-      {servers.map((s) => (
-        <div key={s.hostname}>
-          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 2 }}>
-            <span style={{ fontSize: "var(--decs-fs-body-s)", fontWeight: 600, color: "var(--decs-text-heading)" }}>{s.hostname}</span>
-            <span style={{ fontSize: "var(--decs-fs-body-s)", color: "var(--decs-text-secondary)" }}>GPU {s.gpuCount}개</span>
-          </div>
-          {/* ProgressBar의 status="error"는 진행률이 아니라 "완료(실패)" 취급이라 바 자체가
-              안 그려진다 — 사용률 게이지 용도로는 항상 in-progress로 그리고, 높은 사용률은
-              텍스트 색으로만 강조한다. */}
-          <ProgressBar
-            value={s.gpuUtil}
-            status="in-progress"
-            description={<span style={{ color: s.gpuUtil >= 80 ? "var(--decs-status-error)" : undefined, fontWeight: s.gpuUtil >= 80 ? 700 : undefined }}>{s.gpuUtil}%</span>}
-          />
-        </div>
-      ))}
+      <div style={{ display: "flex", alignItems: "baseline", gap: "var(--decs-space-xs)" }}>
+        <span style={{ fontSize: "var(--decs-fs-heading-l)", fontWeight: 700, color: "var(--decs-text-heading)" }}>{avgUtil}%</span>
+        <span style={{ fontSize: "var(--decs-fs-body-s)", color: "var(--decs-text-secondary)" }}>전체 평균 · 서버 {servers.length}대</span>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-s)" }}>
+        {servers.map((s) => <GpuUtilRow key={s.hostname} server={s} />)}
+      </div>
     </div>
   );
 }

--- a/src/pages/decs-console/user/UserDashboard.jsx
+++ b/src/pages/decs-console/user/UserDashboard.jsx
@@ -1,5 +1,37 @@
 // UserDashboard — "지금 상태 + 다음 행동" (Toss식 행동 중심, Cards 우선)
-import { Container, Header, Button, StatusIndicator, Badge, Alert, KeyValuePairs } from "../../../design-system";
+import { useState } from "react";
+import { Container, Header, Button, StatusIndicator, Badge, Alert, KeyValuePairs, Modal } from "../../../design-system";
+
+const ACTIVITY_STATUS_TYPE = {
+  PENDING: "pending",
+  FULFILLED: "success",
+  DENIED: "error",
+  MODIFICATION_REQUESTED: "pending",
+  MODIFICATION_APPROVED: "success",
+  MODIFICATION_REJECTED: "error",
+};
+
+function ActivityDetailModal({ activity, onDismiss }) {
+  if (!activity) return null;
+  return (
+    <Modal visible header="신청 상세" onDismiss={onDismiss} footer={<Button variant="primary" onClick={onDismiss}>닫기</Button>}>
+      <KeyValuePairs columns={2} items={[
+        { label: "상태", value: <StatusIndicator type={ACTIVITY_STATUS_TYPE[activity.status] ?? "pending"}>{activity.statusLabel}</StatusIndicator> },
+        { label: "신청일", value: activity.createdAt ? String(activity.createdAt).slice(0, 10) : "—" },
+        { label: "서버", value: [activity.serverName, activity.resourceGroupName].filter(Boolean).join(" · ") || "—" },
+        { label: "이미지", value: [activity.imageName, activity.imageVersion].filter(Boolean).join(" ") || "—" },
+        { label: "사용 목적", value: activity.usagePurpose || "—" },
+        { label: "만료 예정일", value: activity.expiresAt ? String(activity.expiresAt).slice(0, 10) : "—" },
+      ]} />
+      {activity.comment ? (
+        <div style={{ marginTop: "var(--decs-space-l)" }}>
+          <div style={{ fontSize: "var(--decs-fs-body-s)", color: "var(--decs-text-inactive)", marginBottom: "var(--decs-space-xxs)" }}>관리자 코멘트</div>
+          <div style={{ fontSize: "var(--decs-fs-body-m)", color: "var(--decs-text-body)" }}>{activity.comment}</div>
+        </div>
+      ) : null}
+    </Modal>
+  );
+}
 
 function BigStatus({ onConnect, onExtend, onDetail, server }) {
   return (
@@ -29,6 +61,8 @@ function BigStatus({ onConnect, onExtend, onDetail, server }) {
 }
 
 function UserDashboard({ onRequest, onConnect, onExtend, onDetail, userName, server, expiryDays, activities = [] }) {
+  const [selectedActivity, setSelectedActivity] = useState(null);
+
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-l)", maxWidth: 900, margin: "0 auto" }}>
       <Header variant="h1" description="GPU 사용 현황과 최근 활동을 확인할 수 있어요.">안녕하세요, {userName}님</Header>
@@ -54,9 +88,36 @@ function UserDashboard({ onRequest, onConnect, onExtend, onDetail, userName, ser
           <Button variant="primary" iconName="plus" onClick={onRequest}>GPU 신청하기</Button>
         </div>
         <Container header={<Header variant="h2">최근 활동</Header>}>
-          <KeyValuePairs columns={1} items={activities} />
+          {activities.length === 0 ? (
+            <div style={{ color: "var(--decs-text-secondary)", fontSize: "var(--decs-fs-body-s)", padding: "8px 0" }}>
+              아직 활동 내역이 없어요.
+            </div>
+          ) : (
+            <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-xs)" }}>
+              {activities.map((activity, i) => (
+                <button
+                  key={activity.requestId ?? i}
+                  onClick={() => setSelectedActivity(activity)}
+                  style={{
+                    display: "flex", justifyContent: "space-between", alignItems: "center",
+                    width: "100%", textAlign: "left", background: "none", border: "none",
+                    borderRadius: "var(--decs-radius-item)", padding: "var(--decs-space-xs) var(--decs-space-xs)",
+                    cursor: "pointer", font: "inherit",
+                  }}
+                >
+                  <div>
+                    <div style={{ fontSize: "var(--decs-fs-body-s)", color: "var(--decs-text-inactive)", marginBottom: "2px" }}>{activity.label}</div>
+                    <div style={{ fontSize: "var(--decs-fs-body-m)", color: "var(--decs-text-body)" }}>{activity.value}</div>
+                  </div>
+                  <span style={{ color: "var(--decs-text-secondary)", fontSize: "var(--decs-fs-body-s)" }}>자세히 &gt;</span>
+                </button>
+              ))}
+            </div>
+          )}
         </Container>
       </div>
+
+      <ActivityDetailModal activity={selectedActivity} onDismiss={() => setSelectedActivity(null)} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Select 드롭다운이 Container 안에서 잘리던 문제 수정 (포털 렌더링)
- 신청서/변경요청/이미지 관리에 새로고침 버튼 + 갱신 시각 추가 (사용자 관리와 통일)
- 사용자 대시보드 최근 활동 클릭 시 상세 모달 확인 가능
- 관리자 대시보드 GPU 패널 디자인 개선 (+ 색상명 버그 수정)

## Test plan
- [x] eslint 통과 (기존 경고만)
- [x] vite build 성공
- [ ] 배포 후 사용자 관리 역할/상태 드롭다운 정상 표시 확인
- [ ] 배포 후 신청서/변경요청/이미지 관리 새로고침 동작 확인

Closes #111, Closes #112, Closes #113