### PR TITLE
fix: GPU 클러스터 사용률 패널 2열 배치

### DIFF
--- a/src/pages/decs-console/admin/AdminDashboard.jsx
+++ b/src/pages/decs-console/admin/AdminDashboard.jsx
@@ -76,7 +76,7 @@ function GpuUtilPanel() {
         <span style={{ fontSize: "var(--decs-fs-heading-l)", fontWeight: 700, color: "var(--decs-text-heading)" }}>{avgUtil}%</span>
         <span style={{ fontSize: "var(--decs-fs-body-s)", color: "var(--decs-text-secondary)" }}>전체 평균 · 서버 {servers.length}대</span>
       </div>
-      <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-s)" }}>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "var(--decs-space-s)" }}>
         {servers.map((s) => <GpuUtilRow key={s.hostname} server={s} />)}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- GPU 사용률 패널의 서버 목록을 1열 → 2열 그리드로 변경 (서버 6대 기준 세로 길이 절반)

## Test plan
- [x] eslint 통과, vite build 성공
Closes #115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the GPU utilization server list to display in a two-column grid for a more compact layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->