### PR TITLE
feat: 관리자 컨테이너 상세에 SSH 접속 명령어 표시, 조회 실패 사유 구체화

### DIFF
--- a/src/hooks/useDecsAdminData.js
+++ b/src/hooks/useDecsAdminData.js
@@ -4,7 +4,7 @@ import userService from "../services/userService";
 import { requestService } from "../services/requestService";
 import { mapAdminContainer } from "../utils/decsMapper";
 
-const ERROR_MESSAGE = "일부 Pod 상세 정보를 불러오지 못했습니다.";
+const GENERIC_ERROR_MESSAGE = "일부 정보를 불러오지 못했습니다.";
 
 function getArrayData(res) {
   if (Array.isArray(res?.data)) return res.data;
@@ -41,6 +41,9 @@ export function useDecsAdminData() {
     }
 
     let hasError = false;
+    // 어떤 컨테이너/데이터가 실패했는지 구체적으로 알려주기 위해 실패 사유를 모은다 —
+    // "일부 정보를 불러오지 못했습니다"만 뜨면 관리자가 뭘 다시 확인해야 할지 알 수 없다.
+    const failureDetails = [];
 
     if (containersResult.status === "fulfilled" && containersResult.value?.status === 200) {
       const activeContainers = getArrayData(containersResult.value);
@@ -62,7 +65,10 @@ export function useDecsAdminData() {
           // Pod 상세도 프로비저닝 상태도 못 가져오면 그 컨테이너가 실제로 정상인지 전혀 알 수
           // 없다는 뜻이라, "확인 불가"를 조용히 pending으로 묻지 않고 오류로 명시한다.
           const couldNotResolveStatus = container.podName && !detail && (!provisioning || provisioning.stage === "unknown");
-          if (couldNotResolveStatus) hasError = true;
+          if (couldNotResolveStatus) {
+            hasError = true;
+            failureDetails.push(container.ubuntuUsername ?? container.podName ?? "알 수 없는 컨테이너");
+          }
           // effectiveStatus는 phase(예: Running)보다 컨테이너 실제 waiting/terminated 사유
           // (CrashLoopBackOff 등)를 우선한다 — phase만 보면 반복 재시작 중인 컨테이너를 놓친다.
           const status = couldNotResolveStatus
@@ -72,9 +78,11 @@ export function useDecsAdminData() {
         }));
       } else {
         hasError = true;
+        failureDetails.push("컨테이너 목록");
       }
     } else {
       hasError = true;
+      failureDetails.push("컨테이너 목록");
     }
 
     if (usersResult.status === "fulfilled" && usersResult.value?.status === 200) {
@@ -83,13 +91,15 @@ export function useDecsAdminData() {
         setUsers(userList);
       } else {
         hasError = true;
+        failureDetails.push("사용자 목록");
       }
     } else {
       hasError = true;
+      failureDetails.push("사용자 목록");
     }
 
     if (hasError) {
-      setError(ERROR_MESSAGE);
+      setError(`${GENERIC_ERROR_MESSAGE} (${failureDetails.join(", ")})`);
     }
   }, []);
 

--- a/src/pages/decs-console/admin/ContainerDetail.jsx
+++ b/src/pages/decs-console/admin/ContainerDetail.jsx
@@ -222,6 +222,9 @@ function ContainerDetail({ item, onBack, onRefetch }) {
           { label: "생성일", value: c.createdAt },
           { label: "만료", value: c.expires },
           { label: "컨테이너", value: c.podContainers.length ? c.podContainers.map((container) => `${container.name} (${container.image})`).join(", ") : "—" },
+          ...(c.sshCommand && c.sshCommand !== "—"
+            ? [{ label: "SSH 접속", value: c.sshCommand, copyable: true, copyText: c.sshCommand }]
+            : []),
         ]} />
       </Container>
     </div>

--- a/src/utils/decsMapper.js
+++ b/src/utils/decsMapper.js
@@ -88,6 +88,18 @@ export function mapAdminContainer(dto) {
   const image = [dto.imageName, dto.imageVersion].filter(Boolean).join(":");
   const detail = dto.podDetail ?? {};
 
+  const ports = getPodExternalPorts(dto);
+  const sshPort = getExternalPort(findPort(ports, "ssh", 22));
+  const jupyterPort = getExternalPort(findPort(ports, "jupyter", 8888));
+  const sshPublicPort = toPublicPort(sshPort);
+  const jupyterPublicPort = toPublicPort(jupyterPort);
+  const sshCommand = sshPort && dto.ubuntuUsername
+    ? `ssh ${dto.ubuntuUsername}@${PUBLIC_HOST} -p ${sshPublicPort ?? sshPort}`
+    : "—";
+  const jupyterUrl = jupyterPort
+    ? `http://${PUBLIC_HOST}:${jupyterPublicPort ?? jupyterPort}`
+    : "—";
+
   return {
     id: String(dto.ubuntuUsername ?? dto.userId),
     requestId: dto.requestId,
@@ -106,6 +118,8 @@ export function mapAdminContainer(dto) {
     statusReason: detail.reason ?? null,
     expires: formatDate(dto.expiresAt),
     image: image || "—",
+    sshCommand,
+    jupyterUrl,
   };
 }
 


### PR DESCRIPTION
## Summary
- 사용자 화면(`mapUserServer`)과 동일한 패턴으로 `mapAdminContainer`에 SSH 접속 명령어 추출 로직 추가 — 컨테이너 상세 페이지에서 직접 접속 명령어를 복사할 수 있음. 데이터는 이미 있었고(podExternalPorts) 가공 로직만 빠져있었습니다.
- `useDecsAdminData`의 "일부 Pod 상세 정보를 불러오지 못했습니다" 에러가 어떤 컨테이너인지 안 알려줘서 관리자가 원인 파악을 못 했던 문제 수정 — 실패한 컨테이너 사용자명/데이터 종류를 메시지에 포함하도록 함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Container details now display an **SSH 접속** row when an SSH connection is available.
  - SSH commands can be copied directly from the container overview.
  - Container connection information now includes available SSH and Jupyter access details.

- **Bug Fixes**
  - Data-loading errors now identify which information could not be retrieved.
  - Missing container, user, or request data is reported with clearer, more specific details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->