### PR TITLE
feat: 사용자 셀프 서비스 컨테이너 재시작 UI 추가

### DIFF
--- a/src/hooks/useDecsUserData.js
+++ b/src/hooks/useDecsUserData.js
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { requestService } from "../services/requestService";
-import { mapUserServer, daysLeft } from "../utils/decsMapper";
+import { mapUserServer, mapPodStatus, daysLeft } from "../utils/decsMapper";
 
 const ERROR_MESSAGE = "실데이터를 불러오지 못해 예시 데이터를 표시합니다.";
 
@@ -19,10 +19,10 @@ function formatExpiresText(expiresAt) {
   return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일 만료`;
 }
 
+// PENDING/FULFILLED 외의 값(PROCESSING, MIGRATING, REBOOTING 등)을 전부 "거절됨"으로
+// 잘못 표시하던 자체 매핑을 없애고, 서버 상태와 동일한 단일 소스(mapPodStatus)를 쓴다.
 function getStatusLabel(status) {
-  if (status === "PENDING") return "대기중";
-  if (status === "FULFILLED") return "승인됨";
-  return "거절됨";
+  return mapPodStatus(status).label;
 }
 
 function mapActivity(request) {
@@ -123,8 +123,9 @@ export function useDecsUserData() {
   const [groupOptions, setGroupOptions] = useState(undefined);
   const [error, setError] = useState(null);
 
-  useEffect(() => {
+  const load = useCallback(({ signal } = {}) => {
     let cancelled = false;
+    if (signal) signal.addEventListener("abort", () => { cancelled = true; });
 
     Promise.allSettled([
       requestService.getApprovedRequests(),
@@ -223,11 +224,13 @@ export function useDecsUserData() {
         setError(ERROR_MESSAGE);
       }
     });
-
-    return () => {
-      cancelled = true;
-    };
   }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    load({ signal: controller.signal });
+    return () => controller.abort();
+  }, [load]);
 
   const server = servers?.[0];
   const expiryDays =
@@ -235,5 +238,5 @@ export function useDecsUserData() {
       ? server.daysLeft
       : null;
 
-  return { server, servers, expiryDays, activities, gpuOptions, envOptions, groupOptions, error };
+  return { server, servers, expiryDays, activities, gpuOptions, envOptions, groupOptions, error, refetch: load };
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -9,5 +9,5 @@
   "shell": {
     "adminTitle": "DECS Admin Console", "userTitle": "DGU GPU Portal", "dashboard": "Dashboard", "containers": "Containers", "myContainer": "My container", "gpuRequest": "GPU request", "requests": "Requests", "requestManagement": "Request management", "changeRequests": "Change requests", "changeManagement": "Change management", "users": "Users", "system": "System", "monitoring": "Monitoring", "resourceMonitoring": "Resource monitoring", "images": "Images", "templates": "Message templates", "account": "Account"
   },
-  "status": { "running": "Running", "provisioning": "Provisioning", "error": "Error", "stopped": "Stopped", "pending": "Pending approval", "denied": "Denied", "unknown": "Unknown", "migrating": "Migrating", "deleted": "Deleted", "crash-loop": "Crash looping", "image-pull-error": "Image pull failed", "oom-killed": "Killed (OOM)", "evicted": "Evicted", "lookup-failed": "Status unavailable" }
+  "status": { "running": "Running", "provisioning": "Provisioning", "error": "Error", "stopped": "Stopped", "pending": "Pending approval", "denied": "Denied", "unknown": "Unknown", "migrating": "Migrating", "rebooting": "Rebooting", "deleted": "Deleted", "crash-loop": "Crash looping", "image-pull-error": "Image pull failed", "oom-killed": "Killed (OOM)", "evicted": "Evicted", "lookup-failed": "Status unavailable" }
 }

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -9,5 +9,5 @@
   "shell": {
     "adminTitle": "DECS 관리자 콘솔", "userTitle": "DGU GPU 포털", "dashboard": "대시보드", "containers": "컨테이너 관리", "myContainer": "내 컨테이너", "gpuRequest": "GPU 신청", "requests": "신청 현황", "requestManagement": "신청서 관리", "changeRequests": "변경 요청 현황", "changeManagement": "변경 요청 관리", "users": "사용자 관리", "system": "시스템", "monitoring": "모니터링", "resourceMonitoring": "리소스 모니터링", "images": "이미지", "templates": "메시지 템플릿", "account": "계정 설정"
   },
-  "status": { "running": "실행 중", "provisioning": "프로비저닝 중", "error": "오류", "stopped": "종료", "pending": "승인 대기", "denied": "거절됨", "unknown": "알 수 없음", "migrating": "마이그레이션 중", "deleted": "삭제됨", "crash-loop": "반복 재시작 중", "image-pull-error": "이미지 가져오기 실패", "oom-killed": "메모리 초과로 종료됨", "evicted": "축출됨", "lookup-failed": "상태 확인 불가" }
+  "status": { "running": "실행 중", "provisioning": "프로비저닝 중", "error": "오류", "stopped": "종료", "pending": "승인 대기", "denied": "거절됨", "unknown": "알 수 없음", "migrating": "마이그레이션 중", "rebooting": "재시작 중", "deleted": "삭제됨", "crash-loop": "반복 재시작 중", "image-pull-error": "이미지 가져오기 실패", "oom-killed": "메모리 초과로 종료됨", "evicted": "축출됨", "lookup-failed": "상태 확인 불가" }
 }

--- a/src/pages/admin/RequestManagementPage.jsx
+++ b/src/pages/admin/RequestManagementPage.jsx
@@ -32,8 +32,14 @@ const STATUS_META = {
   PROCESSING: { type: "in-progress", label: "처리중" },
   FULFILLED: { type: "success", label: "승인됨" },
   DENIED: { type: "error", label: "거절됨" },
+  MIGRATING: { type: "in-progress", label: "마이그레이션 중" },
+  REBOOTING: { type: "in-progress", label: "재시작 중" },
   DELETED: { type: "stopped", label: "삭제됨" },
 };
+
+// 탭/카운트를 이 목록 하나로 유도해, 신규 상태값이 추가돼도 여기 한 곳만 고치면
+// 목록 어딘가에서 행이 조용히 사라지는 일이 없다.
+const STATUS_ORDER = Object.keys(STATUS_META);
 
 const renderStatus = (status) => {
   const meta = STATUS_META[status];
@@ -158,13 +164,9 @@ const RequestManagementPage = () => {
     .filter((request) => request.status === filter)
     .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
 
-  const statusCounts = {
-    PENDING: requestsInPeriod.filter((r) => r.status === "PENDING").length,
-    PROCESSING: requestsInPeriod.filter((r) => r.status === "PROCESSING").length,
-    FULFILLED: requestsInPeriod.filter((r) => r.status === "FULFILLED").length,
-    DENIED: requestsInPeriod.filter((r) => r.status === "DENIED").length,
-    DELETED: requestsInPeriod.filter((r) => r.status === "DELETED").length,
-  };
+  const statusCounts = Object.fromEntries(
+    STATUS_ORDER.map((status) => [status, requestsInPeriod.filter((r) => r.status === status).length])
+  );
 
   const hasMore = visibleCount < filteredRequests.length;
   const pageRequests = filteredRequests.slice(0, visibleCount);
@@ -476,6 +478,8 @@ const RequestManagementPage = () => {
             { key: "PENDING", label: "대기중" },
             { key: "PROCESSING", label: "처리중" },
             { key: "FULFILLED", label: "승인됨" },
+            { key: "MIGRATING", label: "마이그레이션 중" },
+            { key: "REBOOTING", label: "재시작 중" },
             { key: "DENIED", label: "거절됨" },
             { key: "DELETED", label: "삭제됨" },
           ].map((tab) => ({

--- a/src/pages/decs-console/user/UserContainerDetail.jsx
+++ b/src/pages/decs-console/user/UserContainerDetail.jsx
@@ -1,9 +1,12 @@
 // UserContainerDetail — 접속·상태 이해 (친절한 문구 + 복사 가능한 접속 정보)
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Container, Header, KeyValuePairs, StatusIndicator, Button, Alert, ExpandableSection, Badge, FormField, Input, Modal } from "../../../design-system";
+import { requestService } from "../../../services/requestService";
 
-function UserContainerDetail({ onBack, onExtend, servers = [] }) {
+const REBOOT_POLL_INTERVAL_MS = 5_000;
+
+function UserContainerDetail({ onBack, onExtend, onReboot, onRefetch, servers = [] }) {
   const location = useLocation();
   const navigate = useNavigate();
   const [selectedId, setSelectedId] = useState(null);
@@ -13,8 +16,77 @@ function UserContainerDetail({ onBack, onExtend, servers = [] }) {
   const [extendError, setExtendError] = useState(null);
   const [submitting, setSubmitting] = useState(false);
   const [autoExtended, setAutoExtended] = useState(false);
+  const [rebootOpen, setRebootOpen] = useState(false);
+  const [rebootSubmitting, setRebootSubmitting] = useState(false);
+  const [rebootError, setRebootError] = useState(null);
+  const [rebootPolling, setRebootPolling] = useState(false);
+  const pollTimerRef = useRef(null);
+  const polledRequestIdRef = useRef(null);
 
   const server = servers.find((s) => s.requestId === selectedId) ?? servers[0];
+
+  // 페이지를 새로고침했는데 이미 재시작이 진행 중이면(다른 탭에서 눌렀거나 새로고침 전
+  // 폴링이 끊겼거나) 상태 뱃지만 보고도 폴링을 이어서 시작한다.
+  useEffect(() => {
+    if (server && server.statusType === "in-progress" && polledRequestIdRef.current !== server.requestId) {
+      startRebootPolling(server.requestId);
+    }
+    return () => {
+      if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
+    };
+    // startRebootPolling은 매 렌더 새로 생성되는 함수라 deps에 넣으면 폴링이 계속
+    // 재시작된다 — server 식별자/상태가 바뀔 때만 재평가하면 충분하다.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [server?.requestId, server?.statusType]);
+
+  function startRebootPolling(requestId) {
+    polledRequestIdRef.current = requestId;
+    setRebootPolling(true);
+
+    async function poll() {
+      try {
+        const res = await requestService.getApprovedRequests();
+        const list = Array.isArray(res.data?.data) ? res.data.data : Array.isArray(res.data) ? res.data : [];
+        const current = list.find((r) => (r.requestId ?? r.request_id) === requestId);
+        const status = current?.status;
+
+        if (!current || status === "FULFILLED" || status === "DENIED" || status === "DELETED") {
+          setRebootPolling(false);
+          polledRequestIdRef.current = null;
+          await onRefetch?.();
+          return;
+        }
+      } catch {
+        // 폴링 중 일시적인 네트워크 오류는 무시하고 다음 주기에 다시 시도한다.
+      } finally {
+        if (polledRequestIdRef.current === requestId) {
+          pollTimerRef.current = setTimeout(poll, REBOOT_POLL_INTERVAL_MS);
+        }
+      }
+    }
+
+    poll();
+  }
+
+  function openReboot() {
+    setRebootError(null);
+    setRebootOpen(true);
+  }
+
+  async function submitReboot() {
+    setRebootSubmitting(true);
+    setRebootError(null);
+    try {
+      await onReboot(server.requestId);
+      setRebootOpen(false);
+      await onRefetch?.();
+      startRebootPolling(server.requestId);
+    } catch (error) {
+      setRebootError(error.message || "재시작 요청에 실패했어요. 잠시 후 다시 시도해주세요.");
+    } finally {
+      setRebootSubmitting(false);
+    }
+  }
 
   // 대시보드 연장 버튼 경유(location.state.extend) 시 서버 로드 후 모달 자동 오픈
   // eslint-disable-next-line react-hooks/exhaustive-deps -- openExtension은 매 렌더 새로 생성, autoExtended 가드로 1회만 실행
@@ -143,8 +215,24 @@ function UserContainerDetail({ onBack, onExtend, servers = [] }) {
         </Container>
       </div>
 
-      <Alert type="info" header="문제가 있나요?">
-        접속이 안 되면 컨테이너를 재시작해 보세요. 그래도 안 되면 대시보드의 도움말에서 관리자에게 문의할 수 있어요.
+      <Alert
+        type="info"
+        header="문제가 있나요?"
+        action={
+          <Button
+            variant="normal"
+            iconName="arrow-path"
+            loading={rebootPolling}
+            disabled={server.statusType !== "success"}
+            onClick={openReboot}
+          >
+            {rebootPolling ? "재시작 중..." : "컨테이너 재시작"}
+          </Button>
+        }
+      >
+        GPU가 안 잡히거나 접속이 안 되면 컨테이너를 재시작해 보세요. 설치한 패키지나 파일은 그대로 유지되지만,
+        접속 포트 번호가 바뀔 수 있어요(바뀌면 이 페이지의 접속 명령이 자동으로 갱신됩니다).
+        재시작해도 안 되면 대시보드의 도움말에서 관리자에게 문의할 수 있어요.
       </Alert>
 
       <Modal
@@ -180,6 +268,28 @@ function UserContainerDetail({ onBack, onExtend, servers = [] }) {
               }}
             />
           </FormField>
+        </div>
+      </Modal>
+
+      <Modal
+        visible={rebootOpen}
+        onDismiss={() => !rebootSubmitting && setRebootOpen(false)}
+        header="컨테이너 재시작"
+        footer={<>
+          <Button variant="normal" disabled={rebootSubmitting} onClick={() => setRebootOpen(false)}>취소</Button>
+          <Button variant="primary" loading={rebootSubmitting} onClick={submitReboot}>재시작</Button>
+        </>}
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--decs-space-l)" }}>
+          {rebootError ? <Alert type="error">{rebootError}</Alert> : null}
+          <Alert type="warning" header="접속 포트가 바뀔 수 있어요">
+            재시작하면 현재 사용 중인 SSH/Jupyter 접속 포트 번호가 바뀔 수 있습니다. 재시작이 끝나면 이 페이지의
+            접속 정보가 새 포트로 자동 갱신되니, 재시작 후에는 갱신된 접속 명령을 다시 확인해주세요. 설치한
+            패키지나 홈 디렉토리의 파일은 그대로 유지됩니다.
+          </Alert>
+          <div style={{ color: "var(--decs-text-secondary)", fontSize: "var(--decs-fs-body-m)" }}>
+            재시작에는 몇 분 정도 걸릴 수 있고, 완료될 때까지 이 컨테이너에는 접속할 수 없습니다.
+          </div>
         </div>
       </Modal>
     </div>

--- a/src/pages/decs-console/user/UserPortalApp.jsx
+++ b/src/pages/decs-console/user/UserPortalApp.jsx
@@ -20,7 +20,7 @@ function UserPortalApp() {
   const navigate = useNavigate();
   const { user, logout } = useAuth();
   const { t, i18n } = useTranslation();
-  const { server, servers, expiryDays, activities, gpuOptions, envOptions, groupOptions, error } = useDecsUserData();
+  const { server, servers, expiryDays, activities, gpuOptions, envOptions, groupOptions, error, refetch } = useDecsUserData();
   const userName = user?.name || user?.email || "사용자";
   const isAdmin = user?.role === "ADMIN";
 
@@ -78,6 +78,11 @@ function UserPortalApp() {
     navigate("/user/change-requests");
   }
 
+  async function submitReboot(requestId) {
+    const response = await requestService.rebootRequest(requestId);
+    return response.data?.data ?? response.data;
+  }
+
   return (
     <div style={{ height: "100vh" }}>
       <AppLayout
@@ -90,7 +95,7 @@ function UserPortalApp() {
         <Routes>
           <Route index element={<UserDashboard userName={userName} server={server} expiryDays={expiryDays} activities={activities ?? []} onRequest={() => navigate("/user/request")} onConnect={() => navigate("/user/container")} onExtend={() => navigate("/user/container", { state: { extend: true } })} onDetail={() => navigate("/user/container")} />} />
           <Route path="request" element={<RequestWizard onCancel={() => navigate("/user")} onDone={() => navigate("/user/requests")} gpuOptions={gpuOptions ?? []} envOptions={envOptions ?? []} groupOptions={groupOptions ?? []} onSubmit={submitRequest} />} />
-          <Route path="container" element={<UserContainerDetail onBack={() => navigate("/user")} onExtend={submitExtension} servers={servers ?? []} />} />
+          <Route path="container" element={<UserContainerDetail onBack={() => navigate("/user")} onExtend={submitExtension} onReboot={submitReboot} onRefetch={refetch} servers={servers ?? []} />} />
           <Route path="requests" element={<RequestStatusPage />} />
           <Route path="change-requests" element={<MyChangeRequestsPage />} />
           <Route path="account" element={<AccountPage user={user} />} />

--- a/src/services/requestService.js
+++ b/src/services/requestService.js
@@ -55,4 +55,11 @@ export const requestService = {
   getDashboardServers: (status = "ALL") =>
     apiClient.get("/api/dashboard/me/servers", { status }),
   getApprovedRequests: () => apiClient.get("/api/requests/my/approved"),
+
+  rebootRequest: (requestId) =>
+    apiClient.post(`/api/requests/${requestId}/reboot`, {}, {
+      // config-server가 새 Pod 생성을 확인할 때까지 기다리는 admin migrate 호출과 동일한
+      // 타임아웃을 쓴다 — 재부팅도 내부적으로 같은 /migrate 경로를 탄다.
+      signal: AbortSignal.timeout(600_000),
+    }),
 };

--- a/src/utils/decsMapper.js
+++ b/src/utils/decsMapper.js
@@ -30,6 +30,7 @@ const STATUS_MAP = {
   FULFILLED: { type: "success", key: "running" },
   DENIED: { type: "error", key: "denied" },
   MIGRATING: { type: "in-progress", key: "migrating" },
+  REBOOTING: { type: "in-progress", key: "rebooting" },
   DELETED: { type: "stopped", key: "deleted" },
   "lookup-failed": { type: "error", key: "lookup-failed" },
 };


### PR DESCRIPTION
## Summary
- 내 컨테이너 페이지(`UserContainerDetail`)에 재시작 버튼 + 확인 모달 추가, 접속 포트가 바뀔 수 있다는 안내 포함
- 재시작 요청 후 상태를 폴링해 완료되면 접속 정보(SSH/Jupyter)를 자동 갱신
- REBOOTING 상태가 STATUS_MAP/STATUS_META에 없어서 활동 내역에 "거절됨"으로 잘못 뜨거나(사용자), 관리자 신청서 목록 탭에서 행이 통째로 사라지던(관리자) 기존 버그 수정
- 백엔드 API 계약: `POST /api/requests/{requestId}/reboot`, 상태는 `GET /api/requests/my/approved` 폴링으로 확인 (admin_be PR #481 의존)

## Test plan
- [x] `npm run build` 성공
- [x] `npx eslint` 신규/수정 파일 대상 0 errors (기존 raw-px 경고 외 신규 경고 없음)
- [ ] 실제 백엔드(PR #481, admin_infra PR #152) 배포 후 재시작 버튼 E2E 확인 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to reboot user containers with confirmation and progress tracking.
  - Reboot progress continues after page reload and automatically refreshes when complete.
  - Added Migrating and Rebooting statuses to request filters and status displays.
  - Added English and Korean translations for the Rebooting status.

- **Bug Fixes**
  - Improved status labeling for all supported pod states.
  - Added request cancellation and timeout handling to improve data loading reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->