### PR TITLE
fix: 상태 매핑에 누락된 MIGRATING/EXPIRING 처리 추가

### DIFF
--- a/src/hooks/useDecsUserData.js
+++ b/src/hooks/useDecsUserData.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { requestService } from "../services/requestService";
-import { mapUserServer, daysLeft } from "../utils/decsMapper";
+import { mapUserServer, mapPodStatus, daysLeft } from "../utils/decsMapper";
 
 const ERROR_MESSAGE = "실데이터를 불러오지 못해 예시 데이터를 표시합니다.";
 
@@ -19,10 +19,10 @@ function formatExpiresText(expiresAt) {
   return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일 만료`;
 }
 
+// PENDING/FULFILLED 외의 값(PROCESSING, MIGRATING, EXPIRING 등)을 전부 "거절됨"으로
+// 잘못 표시하던 자체 매핑을 없애고, 서버 상태와 동일한 단일 소스(mapPodStatus)를 쓴다.
 function getStatusLabel(status) {
-  if (status === "PENDING") return "대기중";
-  if (status === "FULFILLED") return "승인됨";
-  return "거절됨";
+  return mapPodStatus(status).label;
 }
 
 function mapActivity(request) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -9,5 +9,5 @@
   "shell": {
     "adminTitle": "DECS Admin Console", "userTitle": "DGU GPU Portal", "dashboard": "Dashboard", "containers": "Containers", "myContainer": "My container", "gpuRequest": "GPU request", "requests": "Requests", "requestManagement": "Request management", "changeRequests": "Change requests", "changeManagement": "Change management", "users": "Users", "system": "System", "monitoring": "Monitoring", "resourceMonitoring": "Resource monitoring", "images": "Images", "templates": "Message templates", "account": "Account"
   },
-  "status": { "running": "Running", "provisioning": "Provisioning", "error": "Error", "stopped": "Stopped", "pending": "Pending approval", "denied": "Denied", "unknown": "Unknown", "migrating": "Migrating", "deleted": "Deleted", "crash-loop": "Crash looping", "image-pull-error": "Image pull failed", "oom-killed": "Killed (OOM)", "evicted": "Evicted", "lookup-failed": "Status unavailable" }
+  "status": { "running": "Running", "provisioning": "Provisioning", "error": "Error", "stopped": "Stopped", "pending": "Pending approval", "denied": "Denied", "unknown": "Unknown", "migrating": "Migrating", "expiring": "Expiring", "deleted": "Deleted", "crash-loop": "Crash looping", "image-pull-error": "Image pull failed", "oom-killed": "Killed (OOM)", "evicted": "Evicted", "lookup-failed": "Status unavailable" }
 }

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -9,5 +9,5 @@
   "shell": {
     "adminTitle": "DECS 관리자 콘솔", "userTitle": "DGU GPU 포털", "dashboard": "대시보드", "containers": "컨테이너 관리", "myContainer": "내 컨테이너", "gpuRequest": "GPU 신청", "requests": "신청 현황", "requestManagement": "신청서 관리", "changeRequests": "변경 요청 현황", "changeManagement": "변경 요청 관리", "users": "사용자 관리", "system": "시스템", "monitoring": "모니터링", "resourceMonitoring": "리소스 모니터링", "images": "이미지", "templates": "메시지 템플릿", "account": "계정 설정"
   },
-  "status": { "running": "실행 중", "provisioning": "프로비저닝 중", "error": "오류", "stopped": "종료", "pending": "승인 대기", "denied": "거절됨", "unknown": "알 수 없음", "migrating": "마이그레이션 중", "deleted": "삭제됨", "crash-loop": "반복 재시작 중", "image-pull-error": "이미지 가져오기 실패", "oom-killed": "메모리 초과로 종료됨", "evicted": "축출됨", "lookup-failed": "상태 확인 불가" }
+  "status": { "running": "실행 중", "provisioning": "프로비저닝 중", "error": "오류", "stopped": "종료", "pending": "승인 대기", "denied": "거절됨", "unknown": "알 수 없음", "migrating": "마이그레이션 중", "expiring": "만료 처리 중", "deleted": "삭제됨", "crash-loop": "반복 재시작 중", "image-pull-error": "이미지 가져오기 실패", "oom-killed": "메모리 초과로 종료됨", "evicted": "축출됨", "lookup-failed": "상태 확인 불가" }
 }

--- a/src/pages/admin/RequestManagementPage.jsx
+++ b/src/pages/admin/RequestManagementPage.jsx
@@ -32,8 +32,14 @@ const STATUS_META = {
   PROCESSING: { type: "in-progress", label: "처리중" },
   FULFILLED: { type: "success", label: "승인됨" },
   DENIED: { type: "error", label: "거절됨" },
+  MIGRATING: { type: "in-progress", label: "마이그레이션 중" },
+  EXPIRING: { type: "in-progress", label: "만료 처리 중" },
   DELETED: { type: "stopped", label: "삭제됨" },
 };
+
+// 탭/카운트를 이 목록 하나로 유도해, 신규 상태값이 추가돼도 여기 한 곳만 고치면
+// 목록 어딘가에서 행이 조용히 사라지는 일이 없다.
+const STATUS_ORDER = Object.keys(STATUS_META);
 
 const renderStatus = (status) => {
   const meta = STATUS_META[status];
@@ -158,13 +164,9 @@ const RequestManagementPage = () => {
     .filter((request) => request.status === filter)
     .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
 
-  const statusCounts = {
-    PENDING: requestsInPeriod.filter((r) => r.status === "PENDING").length,
-    PROCESSING: requestsInPeriod.filter((r) => r.status === "PROCESSING").length,
-    FULFILLED: requestsInPeriod.filter((r) => r.status === "FULFILLED").length,
-    DENIED: requestsInPeriod.filter((r) => r.status === "DENIED").length,
-    DELETED: requestsInPeriod.filter((r) => r.status === "DELETED").length,
-  };
+  const statusCounts = Object.fromEntries(
+    STATUS_ORDER.map((status) => [status, requestsInPeriod.filter((r) => r.status === status).length])
+  );
 
   const hasMore = visibleCount < filteredRequests.length;
   const pageRequests = filteredRequests.slice(0, visibleCount);
@@ -476,6 +478,8 @@ const RequestManagementPage = () => {
             { key: "PENDING", label: "대기중" },
             { key: "PROCESSING", label: "처리중" },
             { key: "FULFILLED", label: "승인됨" },
+            { key: "MIGRATING", label: "마이그레이션 중" },
+            { key: "EXPIRING", label: "만료 처리 중" },
             { key: "DENIED", label: "거절됨" },
             { key: "DELETED", label: "삭제됨" },
           ].map((tab) => ({

--- a/src/utils/decsMapper.js
+++ b/src/utils/decsMapper.js
@@ -30,6 +30,7 @@ const STATUS_MAP = {
   FULFILLED: { type: "success", key: "running" },
   DENIED: { type: "error", key: "denied" },
   MIGRATING: { type: "in-progress", key: "migrating" },
+  EXPIRING: { type: "in-progress", key: "expiring" },
   DELETED: { type: "stopped", key: "deleted" },
   "lookup-failed": { type: "error", key: "lookup-failed" },
 };


### PR DESCRIPTION
## Summary
- 관리자 신청서 목록 탭이 MIGRATING/EXPIRING을 몰라서 해당 행이 어느 탭에도 안 걸리고 사라지던 문제 수정
- 사용자 최근 활동 목록에서 PENDING/FULFILLED 외 상태를 전부 "거절됨"으로 표시하던 문제 수정 (공용 mapPodStatus로 통일)
- admin_be에 방금 배포된 EXPIRING 상태 대응

## Test plan
- [x] npm run build 성공
- [x] eslint 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for “Migrating” and “Expiring” request statuses in request management, including status filters and counts.
  * Added English and Korean labels for Expiring, Denied, and Pending statuses.

* **Bug Fixes**
  * Updated status handling to accurately reflect server-provided request states instead of incorrectly categorizing unfamiliar states as rejected.
  * Added consistent in-progress handling for expiring requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->