### PR TITLE
feat: Ubuntu 사용자명을 신청 단위에서 계정 단위로 이전

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,7 +4,8 @@
     "email": "Email", "password": "Password", "confirmPassword": "Confirm password", "name": "Name", "department": "Department", "studentId": "Student ID", "phone": "Phone", "verificationCode": "Verification code",
     "login": "Log in", "signup": "Sign up", "forgot": "Forgot password?", "or": "or", "noAccount": "Need an account?", "hasAccount": "Already have an account?",
     "loginTitle": "DGU AI Lab management system", "signupTitle": "Create your DGU AI Lab account", "emailVerification": "Email verification", "information": "Details", "sendCode": "Send code", "resend": "Resend", "verify": "Verify", "previous": "Previous",
-    "domainHelp": "Use a dgu.ac.kr or dongguk.edu email address.", "slackHelp": "Use the exact same name as your Slack display name to receive notifications."
+    "ubuntuUsername": "Ubuntu username",
+    "domainHelp": "Use a dgu.ac.kr or dongguk.edu email address.", "slackHelp": "Use the exact same name as your Slack display name to receive notifications.", "ubuntuUsernameHelp": "The account name you use to SSH into your containers. Every container you get uses this name, and it cannot be changed after signup."
   },
   "shell": {
     "adminTitle": "DECS Admin Console", "userTitle": "DGU GPU Portal", "dashboard": "Dashboard", "containers": "Containers", "myContainer": "My container", "gpuRequest": "GPU request", "requests": "Requests", "requestManagement": "Request management", "changeRequests": "Change requests", "changeManagement": "Change management", "users": "Users", "system": "System", "monitoring": "Monitoring", "resourceMonitoring": "Resource monitoring", "images": "Images", "templates": "Message templates", "account": "Account"

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -4,7 +4,8 @@
     "email": "이메일", "password": "비밀번호", "confirmPassword": "비밀번호 확인", "name": "이름", "department": "학과", "studentId": "학번", "phone": "전화번호", "verificationCode": "인증번호",
     "login": "로그인", "signup": "회원가입", "forgot": "비밀번호를 잊으셨나요?", "or": "또는", "noAccount": "계정이 없으신가요?", "hasAccount": "이미 계정이 있으신가요?",
     "loginTitle": "동국대학교 AI 연구실 관리 시스템", "signupTitle": "DGU AI Lab 계정을 만들어보세요", "emailVerification": "이메일 인증", "information": "정보 입력", "sendCode": "인증번호 전송", "resend": "재전송", "verify": "인증", "previous": "이전",
-    "domainHelp": "dgu.ac.kr 또는 dongguk.edu 이메일만 사용할 수 있습니다.", "slackHelp": "Slack 표시 이름과 동일하게 입력해야 알림을 받을 수 있습니다."
+    "ubuntuUsername": "Ubuntu 사용자명",
+    "domainHelp": "dgu.ac.kr 또는 dongguk.edu 이메일만 사용할 수 있습니다.", "slackHelp": "Slack 표시 이름과 동일하게 입력해야 알림을 받을 수 있습니다.", "ubuntuUsernameHelp": "컨테이너에 SSH로 접속할 때 쓰는 계정 이름입니다. 앞으로 받는 모든 컨테이너에 같은 이름이 쓰이며, 가입 후에는 변경할 수 없습니다."
   },
   "shell": {
     "adminTitle": "DECS 관리자 콘솔", "userTitle": "DGU GPU 포털", "dashboard": "대시보드", "containers": "컨테이너 관리", "myContainer": "내 컨테이너", "gpuRequest": "GPU 신청", "requests": "신청 현황", "requestManagement": "신청서 관리", "changeRequests": "변경 요청 현황", "changeManagement": "변경 요청 관리", "users": "사용자 관리", "system": "시스템", "monitoring": "모니터링", "resourceMonitoring": "리소스 모니터링", "images": "이미지", "templates": "메시지 템플릿", "account": "계정 설정"

--- a/src/pages/auth/SignupPage.jsx
+++ b/src/pages/auth/SignupPage.jsx
@@ -1,29 +1,59 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Alert, Button, FormField, Input } from "../../design-system";
 import { authService } from "../../services/authService";
+import { requestService } from "../../services/requestService";
+
+const UBUNTU_USERNAME_PATTERN = /^[a-z][a-z0-9_-]{2,49}$/;
+const UBUNTU_USERNAME_FORMAT_ERROR = "소문자로 시작하고 소문자·숫자·_·-만 사용해 3~50자로 입력해주세요.";
+const UBUNTU_USERNAME_TAKEN_ERROR = "이미 사용 중인 Ubuntu 사용자명입니다.";
+const UBUNTU_USERNAME_CHECK_FAILED_ERROR = "사용자명 중복 확인에 실패했습니다. 잠시 후 다시 시도해주세요.";
 
 export default function SignupPage() {
   const { t, i18n } = useTranslation();
   const [step, setStep] = useState(1);
-  const [form, setForm] = useState({ email: "", verificationCode: "", password: "", confirmPassword: "", name: "", department: "", studentId: "", phone: "" });
+  const [form, setForm] = useState({ email: "", verificationCode: "", password: "", confirmPassword: "", name: "", department: "", studentId: "", phone: "", ubuntuUsername: "" });
   const [errors, setErrors] = useState({});
   const [loading, setLoading] = useState(false);
   const [alert, setAlert] = useState(null);
   const [codeSent, setCodeSent] = useState(false);
+  const [usernameStatus, setUsernameStatus] = useState(null);
   const change = (name, value) => { setForm((current) => ({ ...current, [name]: value })); setErrors((current) => ({ ...current, [name]: "" })); };
   const field = (name, type = "text", props = {}) => <FormField label={t(`auth.${name}`)} errorText={errors[name]} {...props}><Input type={type} value={form[name]} onChange={(value) => change(name, value)} invalid={!!errors[name]} {...props} /></FormField>;
   const run = async (work) => { setLoading(true); setAlert(null); try { await work(); } catch (error) { setAlert({ type: "error", message: error.message }); } finally { setLoading(false); } };
+
+  const { ubuntuUsername } = form;
+  useEffect(() => {
+    if (!UBUNTU_USERNAME_PATTERN.test(ubuntuUsername)) { setUsernameStatus(null); return undefined; }
+    setUsernameStatus("checking");
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      try {
+        const response = await requestService.checkUbuntuUsername(ubuntuUsername);
+        const available = response.data?.available ?? response.data?.data?.available;
+        if (!cancelled) setUsernameStatus(available === false ? "taken" : "available");
+      } catch {
+        if (!cancelled) setUsernameStatus("failed");
+      }
+    }, 400);
+    return () => { cancelled = true; clearTimeout(timer); };
+  }, [ubuntuUsername]);
+
+  // 중복 확인이 실패했을 때는 가입 자체를 막지 않고 안내만 한다. 최종 중복 판정은 서버가 한다.
+  const usernameTakenError = usernameStatus === "taken" ? UBUNTU_USERNAME_TAKEN_ERROR : null;
+  const usernameFormatError = ubuntuUsername && !UBUNTU_USERNAME_PATTERN.test(ubuntuUsername) ? UBUNTU_USERNAME_FORMAT_ERROR : null;
+  const usernameError = errors.ubuntuUsername || usernameFormatError || usernameTakenError;
+  const usernameConstraint = usernameStatus === "checking" ? "사용 가능 여부를 확인하는 중이에요." : usernameStatus === "available" ? "사용할 수 있는 이름이에요." : usernameStatus === "failed" ? UBUNTU_USERNAME_CHECK_FAILED_ERROR : t("auth.ubuntuUsernameHelp");
   const send = (event) => { event.preventDefault(); if (!/@(dgu\.ac\.kr|dongguk\.edu)$/.test(form.email)) return setErrors({ email: t("auth.domainHelp") }); run(async () => { const response = await authService.sendEmailVerification(form.email); if (response.status !== 200) throw new Error("인증번호 전송에 실패했습니다."); setCodeSent(true); setAlert({ type: "success", message: "인증번호가 이메일로 전송되었습니다." }); }); };
   const verify = () => { if (!form.verificationCode) return setErrors({ verificationCode: "인증번호를 입력해주세요." }); run(async () => { const response = await authService.verifyEmailCode(form.email, form.verificationCode); if (response.status !== 200) throw new Error("인증번호가 일치하지 않습니다."); setStep(2); }); };
-  const signup = (event) => { event.preventDefault(); const required = ["password", "confirmPassword", "name", "department", "studentId", "phone"]; const next = Object.fromEntries(required.filter((key) => !form[key]).map((key) => [key, `${t(`auth.${key}`)}을(를) 입력해주세요.`])); if (form.password && form.password.length < 8) next.password = "비밀번호는 8자 이상이어야 합니다."; if (form.confirmPassword && form.password !== form.confirmPassword) next.confirmPassword = "비밀번호가 일치하지 않습니다."; setErrors(next); if (Object.keys(next).length) return; run(async () => { const response = await authService.register(form); if (response.status < 200 || response.status >= 300) throw new Error("회원가입에 실패했습니다."); window.location.href = "/login"; }); };
+  const signup = (event) => { event.preventDefault(); const required = ["password", "confirmPassword", "name", "department", "studentId", "phone", "ubuntuUsername"]; const next = Object.fromEntries(required.filter((key) => !form[key]).map((key) => [key, `${t(`auth.${key}`)}을(를) 입력해주세요.`])); if (form.password && form.password.length < 8) next.password = "비밀번호는 8자 이상이어야 합니다."; if (form.confirmPassword && form.password !== form.confirmPassword) next.confirmPassword = "비밀번호가 일치하지 않습니다."; if (form.ubuntuUsername && !UBUNTU_USERNAME_PATTERN.test(form.ubuntuUsername)) next.ubuntuUsername = UBUNTU_USERNAME_FORMAT_ERROR; else if (usernameTakenError) next.ubuntuUsername = usernameTakenError; setErrors(next); if (Object.keys(next).length) return; run(async () => { const response = await authService.register(form); if (response.status < 200 || response.status >= 300) throw new Error("회원가입에 실패했습니다."); window.location.href = "/login"; }); };
 
   return <main className="min-h-screen bg-white py-12 px-4"><div className="mx-auto w-full max-w-sm">
     <div className="flex items-center mb-8"><img src="/dongguk_university_logo.svg" alt="동국대학교 로고" width="153" height="48" className="h-12 w-auto mr-3" /><div><h1 className="text-xl font-bold">{t("auth.signup")}</h1><p className="text-sm text-gray-600">{t("auth.signupTitle")}</p></div></div>
     <div className="mb-8 flex items-center gap-2"><span className="bg-brand-500 text-white px-3 py-1">1</span><div className={`h-1 flex-1 ${step === 2 ? "bg-brand-500" : "bg-gray-200"}`} /><span className={`${step === 2 ? "bg-brand-500 text-white" : "bg-gray-200 text-gray-600"} px-3 py-1`}>2</span></div>
     {alert ? <div className="mb-6"><Alert type={alert.type} dismissible onDismiss={() => setAlert(null)}>{alert.message}</Alert></div> : null}
-    {step === 1 ? <form className="space-y-6" onSubmit={send}>{field("email", "email", { disabled: codeSent, constraintText: t("auth.domainHelp") })}{codeSent ? field("verificationCode") : null}<div className="flex gap-3">{codeSent ? <Button type="submit" loading={loading}>{t("auth.resend")}</Button> : null}<Button type={codeSent ? "button" : "submit"} variant="primary" fullWidth loading={loading} onClick={codeSent ? verify : undefined}>{codeSent ? t("auth.verify") : t("auth.sendCode")}</Button></div></form> : <form className="space-y-6" onSubmit={signup}>{field("email", "email", { disabled: true })}{field("password", "password")}{field("confirmPassword", "password")}{field("name", "text", { constraintText: t("auth.slackHelp") })}{field("department")}{field("studentId")}{field("phone")}<div className="flex gap-3"><Button onClick={() => setStep(1)}>{t("auth.previous")}</Button><Button type="submit" variant="primary" fullWidth loading={loading}>{t("auth.signup")}</Button></div></form>}
+    {step === 1 ? <form className="space-y-6" onSubmit={send}>{field("email", "email", { disabled: codeSent, constraintText: t("auth.domainHelp") })}{codeSent ? field("verificationCode") : null}<div className="flex gap-3">{codeSent ? <Button type="submit" loading={loading}>{t("auth.resend")}</Button> : null}<Button type={codeSent ? "button" : "submit"} variant="primary" fullWidth loading={loading} onClick={codeSent ? verify : undefined}>{codeSent ? t("auth.verify") : t("auth.sendCode")}</Button></div></form> : <form className="space-y-6" onSubmit={signup}>{field("email", "email", { disabled: true })}{field("password", "password")}{field("confirmPassword", "password")}{field("name", "text", { constraintText: t("auth.slackHelp") })}{field("department")}{field("studentId")}{field("phone")}<FormField label={t("auth.ubuntuUsername")} errorText={usernameError} constraintText={usernameConstraint}><Input value={form.ubuntuUsername} onChange={(value) => change("ubuntuUsername", value)} invalid={!!usernameError} placeholder="소문자·숫자, 3~50자 (SSH 로그인 계정)" /></FormField><div className="flex gap-3"><Button onClick={() => setStep(1)}>{t("auth.previous")}</Button><Button type="submit" variant="primary" fullWidth loading={loading || usernameStatus === "checking"}>{t("auth.signup")}</Button></div></form>}
     <p className="mt-6 text-center text-sm text-gray-600">{t("auth.hasAccount")} <Link to="/login" className="font-medium text-brand-500">{t("auth.login")}</Link></p>
     <button className="mt-6 w-full text-sm text-gray-600" onClick={() => i18n.changeLanguage(i18n.language === "en" ? "ko" : "en")}>{t("common.language")}</button>
   </div></main>;

--- a/src/pages/decs-console/user/RequestWizard.jsx
+++ b/src/pages/decs-console/user/RequestWizard.jsx
@@ -1,14 +1,13 @@
 // RequestWizard — 사용 목적 → 서버 선택 → GPU → 기간 → 개발 환경 → 확인
 import React from "react";
 import { Wizard, Cards, FormField, Select, Input, KeyValuePairs, Alert, Container, Header, StatusIndicator, Button, Badge, Table } from "../../../design-system";
-import { requestService } from "../../../services/requestService";
 
 function toLocalDateInput(date) {
   const offset = date.getTimezoneOffset() * 60_000;
   return new Date(date.getTime() - offset).toISOString().slice(0, 10);
 }
 
-function RequestWizard({ onCancel, onDone, gpuOptions: gpuOptionsProp, envOptions: envOptionsProp, groupOptions: groupOptionsProp, onSubmit: onSubmitProp }) {
+function RequestWizard({ onCancel, onDone, gpuOptions: gpuOptionsProp, envOptions: envOptionsProp, groupOptions: groupOptionsProp, onSubmit: onSubmitProp, accountUsername }) {
   const [step, setStep] = React.useState(0);
   const [purpose, setPurpose] = React.useState("");
   const [selectedServer, setSelectedServer] = React.useState("");
@@ -19,7 +18,6 @@ function RequestWizard({ onCancel, onDone, gpuOptions: gpuOptionsProp, envOption
     return toLocalDateInput(d);
   });
   const [env, setEnv] = React.useState("");
-  const [ubuntuUsername, setUbuntuUsername] = React.useState("");
   const [ubuntuPassword, setUbuntuPassword] = React.useState("");
   const [submitting, setSubmitting] = React.useState(false);
   const [done, setDone] = React.useState(false);
@@ -32,7 +30,6 @@ function RequestWizard({ onCancel, onDone, gpuOptions: gpuOptionsProp, envOption
   const [portPurpose, setPortPurpose] = React.useState("");
   const [portRequests, setPortRequests] = React.useState([]);
   const [portError, setPortError] = React.useState(null);
-  const [checkingUsername, setCheckingUsername] = React.useState(false);
 
   const gpuOptions = React.useMemo(() => gpuOptionsProp ?? [], [gpuOptionsProp]);
   const envOptions = React.useMemo(() => envOptionsProp ?? [], [envOptionsProp]);
@@ -53,14 +50,9 @@ function RequestWizard({ onCancel, onDone, gpuOptions: gpuOptionsProp, envOption
   );
   const selectedGroupIds = React.useMemo(() => new Set(selectedGroups.map((g) => g.value)), [selectedGroups]);
   const groupSelectOptions = groupOptions.map((g) => ({ ...g, disabled: selectedGroupIds.has(g.value) }));
-  const ubuntuUsernamePattern = /^[a-z][a-z0-9_-]{2,49}$/;
-  const ubuntuUsernameFormatError = ubuntuUsername && !ubuntuUsernamePattern.test(ubuntuUsername)
-    ? "소문자로 시작하고 소문자·숫자·_·-만 사용해 3~50자로 입력해주세요."
-    : null;
   const ubuntuPasswordLengthError = ubuntuPassword && ubuntuPassword.length < 8
     ? "비밀번호는 8자 이상 입력해주세요."
     : null;
-  const ubuntuUsernameError = envErrors.ubuntuUsername || ubuntuUsernameFormatError;
   const ubuntuPasswordError = envErrors.ubuntuPassword || ubuntuPasswordLengthError;
 
   React.useEffect(() => {
@@ -69,11 +61,6 @@ function RequestWizard({ onCancel, onDone, gpuOptions: gpuOptionsProp, envOption
 
   function validateDevelopmentStep() {
     const nextErrors = {};
-    if (!ubuntuUsername) {
-      nextErrors.ubuntuUsername = "Ubuntu 사용자명을 입력해주세요.";
-    } else if (!ubuntuUsernamePattern.test(ubuntuUsername)) {
-      nextErrors.ubuntuUsername = "소문자로 시작하고 소문자·숫자·_·-만 사용해 3~50자로 입력해주세요.";
-    }
     if (!ubuntuPassword) {
       nextErrors.ubuntuPassword = "Ubuntu 비밀번호를 입력해주세요.";
     } else if (ubuntuPassword.length < 8) {
@@ -118,25 +105,9 @@ function RequestWizard({ onCancel, onDone, gpuOptions: gpuOptionsProp, envOption
     return true;
   }
 
-  async function handleNavigate(nextStep) {
+  function handleNavigate(nextStep) {
     setError(null);
     if (!validateStep(nextStep)) return;
-    if (step === 4 && nextStep > step) {
-      setCheckingUsername(true);
-      try {
-        const response = await requestService.checkUbuntuUsername(ubuntuUsername);
-        const available = response.data?.available ?? response.data?.data?.available;
-        if (available === false) {
-          setEnvErrors((prev) => ({ ...prev, ubuntuUsername: "이미 사용 중인 Ubuntu 사용자명입니다." }));
-          return;
-        }
-      } catch {
-        setEnvErrors((prev) => ({ ...prev, ubuntuUsername: "사용자명 중복 확인에 실패했습니다. 잠시 후 다시 시도해주세요." }));
-        return;
-      } finally {
-        setCheckingUsername(false);
-      }
-    }
     setStep(nextStep);
   }
 
@@ -273,13 +244,13 @@ function RequestWizard({ onCancel, onDone, gpuOptions: gpuOptionsProp, envOption
           <FormField label="기본 환경">
             <Select selectedValue={env} onChange={setEnv} options={envOptions} />
           </FormField>
-          <FormField label="Ubuntu 사용자명" errorText={ubuntuUsernameError}>
-            <Input
-              value={ubuntuUsername}
-              onChange={(value) => { setUbuntuUsername(value); setEnvErrors((prev) => ({ ...prev, ubuntuUsername: null })); }}
-              placeholder="소문자·숫자, 3~50자 (SSH 로그인 계정)"
-              invalid={!!ubuntuUsernameError}
-            />
+          <FormField label="Ubuntu 사용자명" constraintText="가입할 때 정한 계정 이름이라 신청마다 바꿀 수 없어요.">
+            <div style={{ display: "flex", alignItems: "center", gap: "var(--decs-space-xs)", minHeight: 32 }}>
+              <span style={{ color: "var(--decs-text-secondary)", fontSize: "var(--decs-fs-body-m)" }}>본인 계정</span>
+              {accountUsername
+                ? <Badge color="grey">{accountUsername}</Badge>
+                : <span style={{ color: "var(--decs-text-secondary)", fontSize: "var(--decs-fs-body-m)" }}>—</span>}
+            </div>
           </FormField>
           <FormField label="Ubuntu 비밀번호" errorText={ubuntuPasswordError}>
             <Input
@@ -340,7 +311,7 @@ function RequestWizard({ onCancel, onDone, gpuOptions: gpuOptionsProp, envOption
             { label: "GPU", value: (filteredGpuOptions.find((o) => o.id === gpu[0]?.id) || {}).title || "—" },
             { label: "사용 만료일", value: expiresDate || "—" },
             { label: "개발 환경", value: envOptions.find((o) => o.value === env)?.label ?? env },
-            { label: "Ubuntu 사용자명", value: ubuntuUsername || <span style={{ color: "var(--decs-status-warning)", fontWeight: 700 }}>미입력</span> },
+            { label: "Ubuntu 사용자명", value: accountUsername || "—" },
             { label: "공유 그룹", value: selectedGroups.length > 0 ? selectedGroups.map((g) => g.label).join(", ") : "—" },
             { label: "추가 포트", value: portRequests.length > 0 ? portRequests.map((p) => `${p.internalPort} (${p.usagePurpose})`).join(", ") : "—" },
           ]} />
@@ -357,7 +328,6 @@ function RequestWizard({ onCancel, onDone, gpuOptions: gpuOptionsProp, envOption
       !selectedServer ? "서버" : null,
       !selectedGpu ? "GPU" : null,
       !env ? "개발 환경" : null,
-      !ubuntuUsername ? "Ubuntu 사용자명" : null,
       !ubuntuPassword ? "Ubuntu 비밀번호" : null,
     ].filter(Boolean);
     const developmentValid = validateDevelopmentStep();
@@ -373,7 +343,6 @@ function RequestWizard({ onCancel, onDone, gpuOptions: gpuOptionsProp, envOption
       gpu: selectedGpu.id,
       expiresAt: `${expiresDate}T23:59:59`,
       env,
-      ubuntuUsername,
       ubuntuPassword,
       ubuntuGids: selectedGroups.map((g) => g.value),
       portRequests,
@@ -394,7 +363,7 @@ function RequestWizard({ onCancel, onDone, gpuOptions: gpuOptionsProp, envOption
       <Header variant="h1">GPU 신청</Header>
       {error ? <div style={{ marginBottom: "var(--decs-space-m)" }}><Alert type="error">{error}</Alert></div> : null}
       <Container>
-        <Wizard steps={steps} activeStepIndex={step} onNavigate={handleNavigate} onCancel={onCancel} onSubmit={submit} submitLabel="신청하기" isLoadingNextStep={submitting || checkingUsername} />
+        <Wizard steps={steps} activeStepIndex={step} onNavigate={handleNavigate} onCancel={onCancel} onSubmit={submit} submitLabel="신청하기" isLoadingNextStep={submitting} />
       </Container>
     </div>
   );

--- a/src/pages/decs-console/user/UserPortalApp.jsx
+++ b/src/pages/decs-console/user/UserPortalApp.jsx
@@ -89,7 +89,7 @@ function UserPortalApp() {
         {error ? <div style={{ marginBottom: "var(--decs-space-m)" }}><Flashbar items={[{ id: "decs-user-data", type: "warning", header: error, dismissible: false }]} /></div> : null}
         <Routes>
           <Route index element={<UserDashboard userName={userName} server={server} expiryDays={expiryDays} activities={activities ?? []} onRequest={() => navigate("/user/request")} onConnect={() => navigate("/user/container")} onExtend={() => navigate("/user/container", { state: { extend: true } })} onDetail={() => navigate("/user/container")} />} />
-          <Route path="request" element={<RequestWizard onCancel={() => navigate("/user")} onDone={() => navigate("/user/requests")} gpuOptions={gpuOptions ?? []} envOptions={envOptions ?? []} groupOptions={groupOptions ?? []} onSubmit={submitRequest} />} />
+          <Route path="request" element={<RequestWizard onCancel={() => navigate("/user")} onDone={() => navigate("/user/requests")} gpuOptions={gpuOptions ?? []} envOptions={envOptions ?? []} groupOptions={groupOptions ?? []} onSubmit={submitRequest} accountUsername={user?.ubuntuUsername} />} />
           <Route path="container" element={<UserContainerDetail onBack={() => navigate("/user")} onExtend={submitExtension} servers={servers ?? []} />} />
           <Route path="requests" element={<RequestStatusPage />} />
           <Route path="change-requests" element={<MyChangeRequestsPage />} />
@@ -116,7 +116,6 @@ function toRequestPayload(form) {
   return {
     resourceGroupId: parseInt(form.gpu, 10),
     imageId: parseInt(form.env, 10),
-    ubuntuUsername: form.ubuntuUsername,
     ubuntuPassword: form.ubuntuPassword,
     // 30083 신청 DTO의 레거시 필수 필드. PVC UI에서는 노출하지 않는다.
     volumeSizeGiB: 20,

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -58,6 +58,7 @@ export const authService = {
         department: userData.department,
         studentId: userData.studentId,
         phone: userData.phone,
+        ubuntuUsername: userData.ubuntuUsername,
       });
       return response;
     } catch (error) {


### PR DESCRIPTION
## 배경

지금까지 Ubuntu 사용자명은 GPU 신청서마다 새로 입력받았다. 같은 사람이 컨테이너를 두 번 받으면 리눅스 계정도 홈 디렉토리도 따로 생겨서, 이전 컨테이너에서 쓰던 데이터를 이어서 쓸 수가 없었다.

사용자명을 **가입 시점에 한 번만** 정하고 그 이후 받는 모든 컨테이너가 같은 이름을 재사용하도록 바꾼다. 홈 디렉토리도 자연스럽게 공유된다.

백엔드 변경(계정 모델에 `ubuntuUsername` 추가, 신청 시 인증 주체에서 사용자명 도출)과 병행 작업이며, 이 PR은 아래 계약을 전제로 만들었다.

## 변경 내용

**회원가입 (`SignupPage`)**
- 2단계에 Ubuntu 사용자명 입력란 추가
- 형식 검사는 신청 마법사가 쓰던 규칙(`/^[a-z][a-z0-9_-]{2,49}$/`)을 그대로 사용
- 중복 확인도 기존 엔드포인트(`GET /api/requests/config/check-username`)를 그대로 재사용. 입력이 멈춘 뒤 400ms 후에 확인하고, 확인 중에는 가입 버튼을 로딩 상태로 잠근다
- 중복이면 "이미 사용 중인 Ubuntu 사용자명입니다."로 가입을 막는다
- 다만 **중복 확인 요청 자체가 실패한 경우는 가입을 막지 않고 안내만 한다.** 최종 중복 판정은 어차피 서버가 하고(동시 가입 경합도 서버만 막을 수 있다), 확인 API 장애로 가입 경로가 통째로 막히는 쪽이 더 위험하다고 봤다
- `POST /api/auth/register` payload에 `ubuntuUsername` 추가

**GPU 신청 (`RequestWizard`)**
- "개발 환경" 단계의 사용자명 입력란 제거 → 본인 계정명 읽기 전용 표시로 대체
- 확인 단계 요약도 같은 값을 보여준다
- 신청 payload에서 `ubuntuUsername` 제거 — 서버가 인증된 사용자로부터 직접 결정한다
- Ubuntu 비밀번호 입력은 그대로 둔다 (이번 변경 범위 아님)

계정명은 `/api/users/me` 응답(`useAuth().user`)의 `ubuntuUsername`을 쓴다. 아직 응답에 필드가 없으면 `—`로 표시되고 신청 자체는 정상 진행된다.

## 백엔드에 필요한 것

1. `POST /api/auth/register`가 `ubuntuUsername`을 받아 저장 (형식·중복 검증 포함)
2. `GET /api/users/me` 응답에 `ubuntuUsername` 포함
3. `POST /api/requests`가 `ubuntuUsername`을 더 이상 요구하지 않고 인증 주체에서 도출
4. `GET /api/requests/config/check-username`을 **미인증 상태에서도** 호출 가능하게 허용 — 가입 화면에는 아직 토큰이 없다

## 확인

- `npm run build` 통과
- 변경한 파일 `npx eslint` 오류 0건 (`RequestWizard`의 raw px 경고 3건은 이 PR 이전부터 있던 것)
- 백엔드가 아직 없어 실제 호출 검증은 못 했고, 두 흐름은 diff를 따라가며 확인했다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Ubuntu username field during registration, including format validation and availability status.
  * Added guidance explaining that the username is used for SSH access and cannot be changed after signup.
  * Registration now prevents submission when the username is unavailable or invalid.
  * Request forms display the account’s Ubuntu username as read-only, avoiding repeated entry.
  * Added Korean translations for the new username field and guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->