### PR TITLE
feat: 계정 설정에 Ubuntu 유저네임 표시 및 자가 등록

### DIFF
--- a/src/pages/AccountPage.jsx
+++ b/src/pages/AccountPage.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { authService } from "../services/authService";
+import { requestService } from "../services/requestService";
 import {
   Alert,
   Badge,
@@ -13,6 +14,13 @@ import {
   Tabs,
 } from "../design-system";
 import { useAuth } from "../hooks/useAuth";
+
+// SignupPage와 동일한 형식 규칙 — 가입 때 입력칸이 없던 기존 계정을 위한 1회성
+// 등록 폼이라, 서버가 허용하는 값 규칙과 반드시 일치해야 한다.
+const UBUNTU_USERNAME_PATTERN = /^[a-z][a-z0-9_-]{2,49}$/;
+const UBUNTU_USERNAME_FORMAT_ERROR = "소문자로 시작하고 소문자·숫자·_·-만 사용해 3~50자로 입력해주세요.";
+const UBUNTU_USERNAME_TAKEN_ERROR = "이미 사용 중인 Ubuntu 사용자명입니다.";
+const UBUNTU_USERNAME_CHECK_FAILED_ERROR = "사용자명 중복 확인에 실패했습니다. 잠시 후 다시 시도해주세요.";
 
 const AccountPage = ({ user }) => {
   const { updateUser } = useAuth();
@@ -28,6 +36,79 @@ const AccountPage = ({ user }) => {
   const [errors, setErrors] = useState({});
   const [isLoading, setIsLoading] = useState(false);
   const [alert, setAlert] = useState(null);
+
+  // 우분투 유저네임이 아직 없는 계정(이 필드가 생기기 전에 가입한 계정)만 등록 폼을 쓴다.
+  const [ubuntuUsernameInput, setUbuntuUsernameInput] = useState("");
+  const [usernameStatus, setUsernameStatus] = useState(null);
+  const [isRegisteringUsername, setIsRegisteringUsername] = useState(false);
+
+  useEffect(() => {
+    if (!UBUNTU_USERNAME_PATTERN.test(ubuntuUsernameInput)) {
+      setUsernameStatus(null);
+      return undefined;
+    }
+    setUsernameStatus("checking");
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      try {
+        const response = await requestService.checkUbuntuUsername(ubuntuUsernameInput);
+        const available = response.data?.available ?? response.data?.data?.available;
+        if (!cancelled) setUsernameStatus(available === false ? "taken" : "available");
+      } catch {
+        if (!cancelled) setUsernameStatus("failed");
+      }
+    }, 400);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [ubuntuUsernameInput]);
+
+  const usernameTakenError = usernameStatus === "taken" ? UBUNTU_USERNAME_TAKEN_ERROR : null;
+  const usernameFormatError =
+    ubuntuUsernameInput && !UBUNTU_USERNAME_PATTERN.test(ubuntuUsernameInput)
+      ? UBUNTU_USERNAME_FORMAT_ERROR
+      : null;
+  const usernameError = errors.ubuntuUsername || usernameFormatError || usernameTakenError;
+  const usernameConstraint =
+    usernameStatus === "checking"
+      ? "사용 가능 여부를 확인하는 중이에요."
+      : usernameStatus === "available"
+      ? "사용할 수 있는 이름이에요."
+      : usernameStatus === "failed"
+      ? UBUNTU_USERNAME_CHECK_FAILED_ERROR
+      : "컨테이너 SSH 접속·홈 디렉터리에 쓰이는 이름이에요. 한 번 등록하면 바꿀 수 없어요.";
+
+  const handleRegisterUbuntuUsername = async (e) => {
+    e.preventDefault();
+    if (!ubuntuUsernameInput) {
+      setErrors((prev) => ({ ...prev, ubuntuUsername: "유저네임을 입력해주세요." }));
+      return;
+    }
+    if (!UBUNTU_USERNAME_PATTERN.test(ubuntuUsernameInput)) {
+      setErrors((prev) => ({ ...prev, ubuntuUsername: UBUNTU_USERNAME_FORMAT_ERROR }));
+      return;
+    }
+
+    setIsRegisteringUsername(true);
+    setAlert(null);
+    try {
+      const response = await authService.registerUbuntuUsername(ubuntuUsernameInput);
+      if (response.status !== 200) {
+        throw new Error("Ubuntu 유저네임 등록에 실패했습니다.");
+      }
+      setAlert({ type: "success", message: "Ubuntu 유저네임이 등록되었습니다." });
+      setUbuntuUsernameInput("");
+      await updateUser();
+    } catch (error) {
+      setAlert({
+        type: "error",
+        message: error.message || "Ubuntu 유저네임 등록에 실패했습니다.",
+      });
+    } finally {
+      setIsRegisteringUsername(false);
+    }
+  };
 
   useEffect(() => {
     // 사용자 정보 로드
@@ -200,12 +281,58 @@ const AccountPage = ({ user }) => {
           { label: "학번", value: user?.studentId || "학번 정보 없음" },
           { label: "이름", value: user?.name || "이름 정보 없음" },
           { label: "학과", value: user?.department || "학과 정보 없음" },
+          ...(user?.ubuntuUsername
+            ? [{ label: "Ubuntu 유저네임", value: user.ubuntuUsername }]
+            : []),
         ]}
       />
       <p className="text-sm text-(--decs-text-secondary)">
         이메일·학번·이름·학과는 변경할 수 없어요. 변경이 필요하면 관리자에게
         문의해 주세요.
       </p>
+
+      {/* 가입 시 Ubuntu 유저네임을 못 받은 계정(이 필드가 생기기 전에 가입한 계정)만
+          여기서 1회 등록한다 — 한 번 등록하면 다시 바꿀 수 없다. */}
+      {!user?.ubuntuUsername && (
+        <form
+          onSubmit={handleRegisterUbuntuUsername}
+          className="space-y-4 rounded-lg border border-(--decs-border-divider) p-4"
+        >
+          <Header variant="h3">Ubuntu 유저네임 등록</Header>
+          <p className="text-sm text-(--decs-text-secondary)">
+            아직 Ubuntu 유저네임이 등록되어 있지 않아요. 컨테이너를 신청하려면
+            먼저 등록해주세요 — 한 번 등록하면 바꿀 수 없어요.
+          </p>
+          <FormField
+            label="Ubuntu 유저네임"
+            errorText={usernameError}
+            constraintText={usernameConstraint}
+            htmlFor="account-ubuntu-username"
+          >
+            <Input
+              id="account-ubuntu-username"
+              value={ubuntuUsernameInput}
+              onChange={(value) => {
+                setUbuntuUsernameInput(value);
+                if (errors.ubuntuUsername) {
+                  setErrors((prev) => ({ ...prev, ubuntuUsername: "" }));
+                }
+              }}
+              invalid={!!usernameError}
+              placeholder="소문자·숫자, 3~50자 (SSH 로그인 계정)"
+            />
+          </FormField>
+          <div className="flex justify-end">
+            <Button
+              variant="primary"
+              loading={isRegisteringUsername}
+              disabled={isRegisteringUsername || usernameStatus === "checking"}
+            >
+              등록
+            </Button>
+          </div>
+        </form>
+      )}
 
       {/* Editable form */}
       <form onSubmit={handleProfileSubmit} className="space-y-6">

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -134,6 +134,30 @@ export const authService = {
     }
   },
 
+  // 우분투 유저네임 등록 (가입 시 못 정한 기존 계정 전용, 1회성 — 이미 등록돼 있으면 실패)
+  registerUbuntuUsername: async (ubuntuUsername) => {
+    try {
+      const accessToken = authService.getAccessToken();
+      if (!accessToken) {
+        throw new Error("인증 토큰이 없습니다.");
+      }
+
+      const response = await apiClient.request("/api/users/me/ubuntu-username", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json;charset=UTF-8",
+          accept: "application/json;charset=UTF-8",
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ ubuntuUsername }),
+      });
+      return response;
+    } catch (error) {
+      if (error.status) throw error; // API 에러는 status 보존 위해 원본 유지
+      throw new Error(error.message || "우분투 유저네임 등록에 실패했습니다.");
+    }
+  },
+
   // 비밀번호 변경
   changePassword: async (currentPassword, newPassword) => {
     try {


### PR DESCRIPTION
## 배경

계정 설정(마이페이지) 화면에서 본인 Ubuntu 유저네임을 볼 수 없었다. 또한 이 필드가 생기기 전에 가입한 계정은 값이 비어있는데, 등록할 화면이 없었다(백엔드 API는 admin_be PR #487에서 추가).

## 변경

- 기본 정보 탭에 Ubuntu 유저네임 표시 (등록되어 있으면 읽기 전용)
- 등록 안 되어 있으면 회원가입 폼과 동일한 형식 검증 + 실시간 중복 확인을 거치는 등록 폼 표시, `PATCH /api/users/me/ubuntu-username` 호출

## 의존성

admin_be PR #487(`PATCH /api/users/me/ubuntu-username`)이 먼저 머지되어야 실제로 동작한다.

## 테스트

`npm run build` 통과, 변경 파일 `eslint` 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users without an Ubuntu username can now register one from their profile.
  * Added username availability validation with clear success and error messages.
  * Existing Ubuntu usernames are displayed in the profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->