### PR TITLE
feat: 우분투 유저네임 미등록 계정에 로그인 직후 강제 등록 모달 추가

### DIFF
--- a/src/components/Auth/UbuntuUsernameRegisterForm.jsx
+++ b/src/components/Auth/UbuntuUsernameRegisterForm.jsx
@@ -1,0 +1,119 @@
+import { useState, useEffect } from "react";
+import { authService } from "../../services/authService";
+import { requestService } from "../../services/requestService";
+import { Alert, Button, FormField, Input } from "../../design-system";
+import { useAuth } from "../../hooks/useAuth";
+
+// SignupPage와 동일한 형식 규칙 — 가입 때 입력칸이 없던 기존 계정을 위한 1회성
+// 등록 폼이라, 서버가 허용하는 값 규칙과 반드시 일치해야 한다.
+const UBUNTU_USERNAME_PATTERN = /^[a-z][a-z0-9_-]{2,49}$/;
+const UBUNTU_USERNAME_FORMAT_ERROR = "소문자로 시작하고 소문자·숫자·_·-만 사용해 3~50자로 입력해주세요.";
+const UBUNTU_USERNAME_TAKEN_ERROR = "이미 사용 중인 Ubuntu 사용자명입니다.";
+const UBUNTU_USERNAME_CHECK_FAILED_ERROR = "사용자명 중복 확인에 실패했습니다. 잠시 후 다시 시도해주세요.";
+
+// AccountPage(마이페이지)의 1회성 필드와 로그인 직후 강제 모달이 이 컴포넌트를 함께 쓴다 —
+// 검증 규칙이 두 곳에서 어긋나면 한쪽에서만 통과되는 값이 생기므로 반드시 하나로 유지한다.
+export function UbuntuUsernameRegisterForm({ onSuccess, formId, autoFocus = false }) {
+  const { updateUser } = useAuth();
+  const [value, setValue] = useState("");
+  const [fieldError, setFieldError] = useState("");
+  const [usernameStatus, setUsernameStatus] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState(null);
+
+  useEffect(() => {
+    if (!UBUNTU_USERNAME_PATTERN.test(value)) {
+      setUsernameStatus(null);
+      return undefined;
+    }
+    setUsernameStatus("checking");
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      try {
+        const response = await requestService.checkUbuntuUsername(value);
+        const available = response.data?.available ?? response.data?.data?.available;
+        if (!cancelled) setUsernameStatus(available === false ? "taken" : "available");
+      } catch {
+        if (!cancelled) setUsernameStatus("failed");
+      }
+    }, 400);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [value]);
+
+  const usernameTakenError = usernameStatus === "taken" ? UBUNTU_USERNAME_TAKEN_ERROR : null;
+  const usernameFormatError =
+    value && !UBUNTU_USERNAME_PATTERN.test(value) ? UBUNTU_USERNAME_FORMAT_ERROR : null;
+  const usernameError = fieldError || usernameFormatError || usernameTakenError;
+  const usernameConstraint =
+    usernameStatus === "checking"
+      ? "사용 가능 여부를 확인하는 중이에요."
+      : usernameStatus === "available"
+      ? "사용할 수 있는 이름이에요."
+      : usernameStatus === "failed"
+      ? UBUNTU_USERNAME_CHECK_FAILED_ERROR
+      : "컨테이너 SSH 접속·홈 디렉터리에 쓰이는 이름이에요. 한 번 등록하면 바꿀 수 없어요.";
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!value) {
+      setFieldError("유저네임을 입력해주세요.");
+      return;
+    }
+    if (!UBUNTU_USERNAME_PATTERN.test(value)) {
+      setFieldError(UBUNTU_USERNAME_FORMAT_ERROR);
+      return;
+    }
+
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const response = await authService.registerUbuntuUsername(value);
+      if (response.status !== 200) {
+        throw new Error("Ubuntu 유저네임 등록에 실패했습니다.");
+      }
+      const result = await updateUser();
+      onSuccess?.(result.user);
+    } catch (error) {
+      setSubmitError(error.message || "Ubuntu 유저네임 등록에 실패했습니다.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form id={formId} onSubmit={handleSubmit} className="space-y-4">
+      {submitError ? <Alert type="error">{submitError}</Alert> : null}
+      <FormField
+        label="Ubuntu 유저네임"
+        errorText={usernameError}
+        constraintText={usernameConstraint}
+        htmlFor={formId ? `${formId}-input` : "ubuntu-username-input"}
+      >
+        <Input
+          id={formId ? `${formId}-input` : "ubuntu-username-input"}
+          value={value}
+          onChange={(v) => {
+            setValue(v);
+            if (fieldError) setFieldError("");
+          }}
+          invalid={!!usernameError}
+          placeholder="소문자·숫자, 3~50자 (SSH 로그인 계정)"
+          autoFocus={autoFocus}
+        />
+      </FormField>
+      <div className="flex justify-end">
+        <Button
+          type="submit"
+          variant="primary"
+          loading={submitting}
+          disabled={submitting || usernameStatus === "checking"}
+        >
+          등록
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -3,6 +3,7 @@ import { authService } from "../services/authService";
 import { Button, Modal } from "../design-system";
 import { useTranslation } from "react-i18next";
 import { sessionEventManager } from "../services/sessionEventManager";
+import { UbuntuUsernameRegisterForm } from "../components/Auth/UbuntuUsernameRegisterForm";
 
 const AuthContext = createContext(null);
 
@@ -169,11 +170,23 @@ export const AuthProvider = ({ children }) => {
     handleSessionExpired,
   };
 
+  // 가입 시점에 우분투 유저네임을 못 받은 계정은 로그인 직후부터 컨테이너 신청이
+  // 막혀 있다(UBUNTU_USERNAME_NOT_ASSIGNED). 마이페이지까지 스스로 찾아가지 않으면
+  // 영영 등록을 못 하는 사용자가 많아, 등록 전에는 닫을 수 없는 모달로 바로 요구한다.
+  // 관리자 계정도 예외 없이 뜬다.
+  const needsUbuntuUsername = !isLoading && isAuthenticated && !!user && !user.ubuntuUsername;
+
   return (
     <AuthContext.Provider value={value}>
       {children}
       <Modal visible={showSessionExpiredModal} onDismiss={handleSessionExpiredConfirm} header={sessionEndReason === "ACCOUNT_DISABLED" ? "계정 비활성화" : "다시 로그인이 필요합니다"} size="small" footer={<Button variant="primary" onClick={handleSessionExpiredConfirm}>{sessionEndReason === "ACCOUNT_DISABLED" ? "확인" : t("auth.login")}</Button>}>
         {sessionEndReason === "ACCOUNT_DISABLED" ? "계정이 비활성화되었습니다. 관리자에게 문의하세요." : "보안 업데이트 또는 세션 만료로 로그인이 해제되었습니다. 다시 로그인해주세요."}
+      </Modal>
+      <Modal visible={needsUbuntuUsername} dismissible={false} header="Ubuntu 유저네임 등록이 필요합니다" size="small">
+        <p style={{ marginTop: 0 }}>
+          컨테이너 신청·SSH 접속에 쓰이는 Ubuntu 유저네임이 아직 없어요. 등록해야 서비스를 계속 이용할 수 있어요 — 한 번 등록하면 바꿀 수 없어요.
+        </p>
+        <UbuntuUsernameRegisterForm formId="mandatory-ubuntu-username" autoFocus />
       </Modal>
     </AuthContext.Provider>
   );

--- a/src/design-system/components/forms/Input.jsx
+++ b/src/design-system/components/forms/Input.jsx
@@ -5,7 +5,7 @@ import { Icon } from "../icons/Icon.jsx";
  * Input — single-line text/number input matching Cloudscape. Set `invalid` to
  * show the error border (pair with FormField errorText). Optional leading icon.
  */
-export function Input({ value, onChange, placeholder, type = "text", disabled, invalid, readOnly, iconName, id, ariaLabel, onKeyDown, style }) {
+export function Input({ value, onChange, placeholder, type = "text", disabled, invalid, readOnly, iconName, id, ariaLabel, onKeyDown, autoFocus, style }) {
   const [focus, setFocus] = React.useState(false);
   const borderColor = invalid
     ? "var(--decs-status-error)"
@@ -26,6 +26,7 @@ export function Input({ value, onChange, placeholder, type = "text", disabled, i
         placeholder={placeholder}
         disabled={disabled}
         readOnly={readOnly}
+        autoFocus={autoFocus}
         aria-label={ariaLabel}
         aria-invalid={invalid || undefined}
         onKeyDown={onKeyDown}

--- a/src/design-system/components/layout/Modal.jsx
+++ b/src/design-system/components/layout/Modal.jsx
@@ -8,7 +8,7 @@ import { Icon } from "../icons/Icon.jsx";
  */
 let modalIdCounter = 0;
 
-export function Modal({ visible, onDismiss, header, children, footer, size = "medium", style }) {
+export function Modal({ visible, onDismiss, header, children, footer, size = "medium", style, dismissible = true }) {
   const titleId = React.useRef(`decs-modal-title-${++modalIdCounter}`).current;
   const dialogRef = React.useRef(null);
 
@@ -22,17 +22,17 @@ export function Modal({ visible, onDismiss, header, children, footer, size = "me
   }, [visible]);
 
   React.useEffect(() => {
-    if (!visible) return;
+    if (!visible || !dismissible) return;
     const onKeyDown = (e) => { if (e.key === "Escape") onDismiss?.(); };
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [visible, onDismiss]);
+  }, [visible, dismissible, onDismiss]);
 
   if (!visible) return null;
   const widths = { small: "400px", medium: "600px", large: "800px" };
   return (
     <div
-      onMouseDown={(e) => { if (e.target === e.currentTarget) onDismiss?.(); }}
+      onMouseDown={(e) => { if (dismissible && e.target === e.currentTarget) onDismiss?.(); }}
       style={{
         position: "fixed", inset: 0, zIndex: 1000,
         background: "rgba(0, 7, 22, 0.35)",
@@ -56,9 +56,11 @@ export function Modal({ visible, onDismiss, header, children, footer, size = "me
       >
         <div style={{ display: "flex", alignItems: "flex-start", gap: "var(--decs-space-m)", padding: "var(--decs-space-xl) var(--decs-space-xl) var(--decs-space-m)" }}>
           <h2 id={titleId} style={{ flex: 1, margin: 0, fontSize: "var(--decs-fs-heading-l)", lineHeight: "var(--decs-lh-heading-l)", fontWeight: "var(--decs-fw-bold)", color: "var(--decs-text-heading)" }}>{header}</h2>
-          <button onClick={onDismiss} aria-label="Close" style={{ background: "none", border: "none", cursor: "pointer", color: "var(--decs-text-secondary)", display: "inline-flex", padding: "var(--decs-space-xs)" }}>
-            <Icon name="x-mark" size={18} />
-          </button>
+          {dismissible ? (
+            <button onClick={onDismiss} aria-label="Close" style={{ background: "none", border: "none", cursor: "pointer", color: "var(--decs-text-secondary)", display: "inline-flex", padding: "var(--decs-space-xs)" }}>
+              <Icon name="x-mark" size={18} />
+            </button>
+          ) : null}
         </div>
         <div style={{ padding: "0 var(--decs-space-xl) var(--decs-space-xl)", overflowY: "auto", fontSize: "var(--decs-fs-body-m)", lineHeight: "var(--decs-lh-body-m)", color: "var(--decs-text-body)" }}>
           {children}

--- a/src/pages/AccountPage.jsx
+++ b/src/pages/AccountPage.jsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
 import { authService } from "../services/authService";
-import { requestService } from "../services/requestService";
 import {
   Alert,
   Badge,
@@ -14,13 +13,7 @@ import {
   Tabs,
 } from "../design-system";
 import { useAuth } from "../hooks/useAuth";
-
-// SignupPage와 동일한 형식 규칙 — 가입 때 입력칸이 없던 기존 계정을 위한 1회성
-// 등록 폼이라, 서버가 허용하는 값 규칙과 반드시 일치해야 한다.
-const UBUNTU_USERNAME_PATTERN = /^[a-z][a-z0-9_-]{2,49}$/;
-const UBUNTU_USERNAME_FORMAT_ERROR = "소문자로 시작하고 소문자·숫자·_·-만 사용해 3~50자로 입력해주세요.";
-const UBUNTU_USERNAME_TAKEN_ERROR = "이미 사용 중인 Ubuntu 사용자명입니다.";
-const UBUNTU_USERNAME_CHECK_FAILED_ERROR = "사용자명 중복 확인에 실패했습니다. 잠시 후 다시 시도해주세요.";
+import { UbuntuUsernameRegisterForm } from "../components/Auth/UbuntuUsernameRegisterForm";
 
 const AccountPage = ({ user }) => {
   const { updateUser } = useAuth();
@@ -36,79 +29,6 @@ const AccountPage = ({ user }) => {
   const [errors, setErrors] = useState({});
   const [isLoading, setIsLoading] = useState(false);
   const [alert, setAlert] = useState(null);
-
-  // 우분투 유저네임이 아직 없는 계정(이 필드가 생기기 전에 가입한 계정)만 등록 폼을 쓴다.
-  const [ubuntuUsernameInput, setUbuntuUsernameInput] = useState("");
-  const [usernameStatus, setUsernameStatus] = useState(null);
-  const [isRegisteringUsername, setIsRegisteringUsername] = useState(false);
-
-  useEffect(() => {
-    if (!UBUNTU_USERNAME_PATTERN.test(ubuntuUsernameInput)) {
-      setUsernameStatus(null);
-      return undefined;
-    }
-    setUsernameStatus("checking");
-    let cancelled = false;
-    const timer = setTimeout(async () => {
-      try {
-        const response = await requestService.checkUbuntuUsername(ubuntuUsernameInput);
-        const available = response.data?.available ?? response.data?.data?.available;
-        if (!cancelled) setUsernameStatus(available === false ? "taken" : "available");
-      } catch {
-        if (!cancelled) setUsernameStatus("failed");
-      }
-    }, 400);
-    return () => {
-      cancelled = true;
-      clearTimeout(timer);
-    };
-  }, [ubuntuUsernameInput]);
-
-  const usernameTakenError = usernameStatus === "taken" ? UBUNTU_USERNAME_TAKEN_ERROR : null;
-  const usernameFormatError =
-    ubuntuUsernameInput && !UBUNTU_USERNAME_PATTERN.test(ubuntuUsernameInput)
-      ? UBUNTU_USERNAME_FORMAT_ERROR
-      : null;
-  const usernameError = errors.ubuntuUsername || usernameFormatError || usernameTakenError;
-  const usernameConstraint =
-    usernameStatus === "checking"
-      ? "사용 가능 여부를 확인하는 중이에요."
-      : usernameStatus === "available"
-      ? "사용할 수 있는 이름이에요."
-      : usernameStatus === "failed"
-      ? UBUNTU_USERNAME_CHECK_FAILED_ERROR
-      : "컨테이너 SSH 접속·홈 디렉터리에 쓰이는 이름이에요. 한 번 등록하면 바꿀 수 없어요.";
-
-  const handleRegisterUbuntuUsername = async (e) => {
-    e.preventDefault();
-    if (!ubuntuUsernameInput) {
-      setErrors((prev) => ({ ...prev, ubuntuUsername: "유저네임을 입력해주세요." }));
-      return;
-    }
-    if (!UBUNTU_USERNAME_PATTERN.test(ubuntuUsernameInput)) {
-      setErrors((prev) => ({ ...prev, ubuntuUsername: UBUNTU_USERNAME_FORMAT_ERROR }));
-      return;
-    }
-
-    setIsRegisteringUsername(true);
-    setAlert(null);
-    try {
-      const response = await authService.registerUbuntuUsername(ubuntuUsernameInput);
-      if (response.status !== 200) {
-        throw new Error("Ubuntu 유저네임 등록에 실패했습니다.");
-      }
-      setAlert({ type: "success", message: "Ubuntu 유저네임이 등록되었습니다." });
-      setUbuntuUsernameInput("");
-      await updateUser();
-    } catch (error) {
-      setAlert({
-        type: "error",
-        message: error.message || "Ubuntu 유저네임 등록에 실패했습니다.",
-      });
-    } finally {
-      setIsRegisteringUsername(false);
-    }
-  };
 
   useEffect(() => {
     // 사용자 정보 로드
@@ -292,46 +212,20 @@ const AccountPage = ({ user }) => {
       </p>
 
       {/* 가입 시 Ubuntu 유저네임을 못 받은 계정(이 필드가 생기기 전에 가입한 계정)만
-          여기서 1회 등록한다 — 한 번 등록하면 다시 바꿀 수 없다. */}
+          여기서 1회 등록한다 — 한 번 등록하면 다시 바꿀 수 없다. 로그인 직후 강제
+          모달(AuthContext)에서 이미 등록했다면 보통 이 블록까지 올 일은 없다. */}
       {!user?.ubuntuUsername && (
-        <form
-          onSubmit={handleRegisterUbuntuUsername}
-          className="space-y-4 rounded-lg border border-(--decs-border-divider) p-4"
-        >
+        <div className="space-y-4 rounded-lg border border-(--decs-border-divider) p-4">
           <Header variant="h3">Ubuntu 유저네임 등록</Header>
           <p className="text-sm text-(--decs-text-secondary)">
             아직 Ubuntu 유저네임이 등록되어 있지 않아요. 컨테이너를 신청하려면
             먼저 등록해주세요 — 한 번 등록하면 바꿀 수 없어요.
           </p>
-          <FormField
-            label="Ubuntu 유저네임"
-            errorText={usernameError}
-            constraintText={usernameConstraint}
-            htmlFor="account-ubuntu-username"
-          >
-            <Input
-              id="account-ubuntu-username"
-              value={ubuntuUsernameInput}
-              onChange={(value) => {
-                setUbuntuUsernameInput(value);
-                if (errors.ubuntuUsername) {
-                  setErrors((prev) => ({ ...prev, ubuntuUsername: "" }));
-                }
-              }}
-              invalid={!!usernameError}
-              placeholder="소문자·숫자, 3~50자 (SSH 로그인 계정)"
-            />
-          </FormField>
-          <div className="flex justify-end">
-            <Button
-              variant="primary"
-              loading={isRegisteringUsername}
-              disabled={isRegisteringUsername || usernameStatus === "checking"}
-            >
-              등록
-            </Button>
-          </div>
-        </form>
+          <UbuntuUsernameRegisterForm
+            formId="account-ubuntu-username"
+            onSuccess={() => setAlert({ type: "success", message: "Ubuntu 유저네임이 등록되었습니다." })}
+          />
+        </div>
       )}
 
       {/* Editable form */}


### PR DESCRIPTION
## 배경
Ubuntu 유저네임 자가 등록 필드(#127)가 계정 설정 페이지 안에서만 보여서, 그 페이지를 스스로 찾아가지 않으면 컨테이너 신청이 막힌 채(UBUNTU_USERNAME_NOT_ASSIGNED) 방치되는 계정이 있었습니다.

## 변경 사항
- `Modal` 공용 컴포넌트에 `dismissible` prop 추가 (기본값 true, 기존 모달 전부 영향 없음). `false`면 X 버튼 미표시 + ESC/배경 클릭 무시.
- 계정 설정 페이지의 등록 폼 로직을 `UbuntuUsernameRegisterForm` 공용 컴포넌트로 분리.
- 로그인 후 유저네임이 없는 계정은 역할(관리자 포함) 구분 없이 닫을 수 없는 모달로 바로 등록을 요구하도록 `AuthContext`에 추가. 등록 성공 시 자동으로 닫힘.
- 계정 설정 페이지는 그대로 유지해 등록된 유저네임을 계속 확인할 수 있습니다.

## 테스트
- `npm run build`, `eslint` 통과 확인
- 운영 백엔드로 프록시되는 dev 서버 특성상 실제 로그인 테스트 계정이 없어 브라우저에서 전체 흐름(로그인 → 모달 노출 → 등록 → 자동 닫힘)은 직접 확인하지 못했습니다. 머지 전 실제 계정으로 한 번 확인 부탁드립니다.