### PR TITLE
fix: 우분투 유저네임 모달 폭·문구 정리, 계정 설정 중복 등록 폼 제거

### DIFF
--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -182,9 +182,10 @@ export const AuthProvider = ({ children }) => {
       <Modal visible={showSessionExpiredModal} onDismiss={handleSessionExpiredConfirm} header={sessionEndReason === "ACCOUNT_DISABLED" ? "계정 비활성화" : "다시 로그인이 필요합니다"} size="small" footer={<Button variant="primary" onClick={handleSessionExpiredConfirm}>{sessionEndReason === "ACCOUNT_DISABLED" ? "확인" : t("auth.login")}</Button>}>
         {sessionEndReason === "ACCOUNT_DISABLED" ? "계정이 비활성화되었습니다. 관리자에게 문의하세요." : "보안 업데이트 또는 세션 만료로 로그인이 해제되었습니다. 다시 로그인해주세요."}
       </Modal>
-      <Modal visible={needsUbuntuUsername} dismissible={false} header="Ubuntu 유저네임 등록이 필요합니다" size="small">
+      <Modal visible={needsUbuntuUsername} dismissible={false} header="Ubuntu 유저네임 등록이 필요합니다" size="medium">
         <p style={{ marginTop: 0 }}>
-          컨테이너 신청·SSH 접속에 쓰이는 Ubuntu 유저네임이 아직 없어요. 등록해야 서비스를 계속 이용할 수 있어요 — 한 번 등록하면 바꿀 수 없어요.
+          컨테이너 신청과 SSH 접속에 쓰이는 Ubuntu 유저네임이 아직 없어요. 등록해야 서비스를 계속 이용할 수 있어요.
+          한 번 등록하면 바꿀 수 없으니 신중하게 정해주세요.
         </p>
         <UbuntuUsernameRegisterForm formId="mandatory-ubuntu-username" autoFocus />
       </Modal>

--- a/src/pages/AccountPage.jsx
+++ b/src/pages/AccountPage.jsx
@@ -13,7 +13,6 @@ import {
   Tabs,
 } from "../design-system";
 import { useAuth } from "../hooks/useAuth";
-import { UbuntuUsernameRegisterForm } from "../components/Auth/UbuntuUsernameRegisterForm";
 
 const AccountPage = ({ user }) => {
   const { updateUser } = useAuth();
@@ -210,23 +209,6 @@ const AccountPage = ({ user }) => {
         이메일·학번·이름·학과는 변경할 수 없어요. 변경이 필요하면 관리자에게
         문의해 주세요.
       </p>
-
-      {/* 가입 시 Ubuntu 유저네임을 못 받은 계정(이 필드가 생기기 전에 가입한 계정)만
-          여기서 1회 등록한다 — 한 번 등록하면 다시 바꿀 수 없다. 로그인 직후 강제
-          모달(AuthContext)에서 이미 등록했다면 보통 이 블록까지 올 일은 없다. */}
-      {!user?.ubuntuUsername && (
-        <div className="space-y-4 rounded-lg border border-(--decs-border-divider) p-4">
-          <Header variant="h3">Ubuntu 유저네임 등록</Header>
-          <p className="text-sm text-(--decs-text-secondary)">
-            아직 Ubuntu 유저네임이 등록되어 있지 않아요. 컨테이너를 신청하려면
-            먼저 등록해주세요 — 한 번 등록하면 바꿀 수 없어요.
-          </p>
-          <UbuntuUsernameRegisterForm
-            formId="account-ubuntu-username"
-            onSuccess={() => setAlert({ type: "success", message: "Ubuntu 유저네임이 등록되었습니다." })}
-          />
-        </div>
-      )}
 
       {/* Editable form */}
       <form onSubmit={handleProfileSubmit} className="space-y-6">


### PR DESCRIPTION
## 변경 사항
- 강제 등록 모달 크기를 small(400px) → medium(600px)으로.
- 안내 문구를 대시(—)로 이어 붙이던 걸 문장 두 개로 분리.
- 로그인 직후 강제 모달이 이미 등록을 요구하므로, 계정 설정 페이지의 중복 등록 폼(#128에서 넣었던 인라인 폼)을 제거. 등록된 유저네임 확인만 남김.