### PR TITLE
feat: 승인 진행 상황 폴링을 username에서 requestId 기준으로 변경

### DIFF
--- a/src/pages/admin/RequestManagementPage.jsx
+++ b/src/pages/admin/RequestManagementPage.jsx
@@ -63,7 +63,11 @@ const RequestManagementPage = () => {
   const sentinelRef = useRef(null);
   const [alert, setAlert] = useState(null);
   const [processingRequestId, setProcessingRequestId] = useState(null);
-  const [processingUsername, setProcessingUsername] = useState(null);
+  // 승인 처리 중인 신청의 진행 상황 폴링 키. 한 사용자가 신청을 여러 개 동시에 가질 수
+  // 있어(계정은 하나로 통합됐지만 Pod는 여러 개 발급 가능) username이 아니라 requestId로
+  // 구분한다 — processingRequestId는 버튼 중복 클릭 방지용이라 응답이 오면 바로 풀리는데,
+  // 이 값은 비동기 후처리(Pod 생성)가 끝날 때까지 별도로 살아있어야 해서 상태를 분리했다.
+  const [pollingRequestId, setPollingRequestId] = useState(null);
   const [provisioningStatus, setProvisioningStatus] = useState(null);
 
   // 목록에 PROCESSING 상태인 신청서가 있으면(다른 관리자가 처리 중이거나, 내가 승인 처리
@@ -73,11 +77,11 @@ const RequestManagementPage = () => {
 
   // 승인 처리 중(Pod 생성 포함)일 때 config-server의 세세한 진행 단계를 폴링해서 보여준다.
   // 조회 실패는 승인 흐름 자체에 영향을 주지 않으므로 조용히 무시한다.
-  const provisioningTargetUsername =
-    processingUsername || processingListRequest?.ubuntu_username || null;
+  const provisioningTargetRequestId =
+    pollingRequestId || processingListRequest?.request_id || null;
 
   useEffect(() => {
-    if (!provisioningTargetUsername) {
+    if (!provisioningTargetRequestId) {
       setProvisioningStatus(null);
       return;
     }
@@ -85,7 +89,7 @@ const RequestManagementPage = () => {
     let intervalId = null;
     const poll = async () => {
       try {
-        const res = await podService.getProvisioningStatus(provisioningTargetUsername);
+        const res = await podService.getProvisioningStatus(provisioningTargetRequestId);
         const data = res?.data ?? null;
         if (cancelled) return;
         if (data) {
@@ -103,7 +107,7 @@ const RequestManagementPage = () => {
           // 여기서 멈추지 않으면 다음 폴링(1초 뒤)에도 같은 stage를 또 감지해서
           // fetchRequests()와 배너 갱신이 끝없이 반복되며 화면이 계속 깜빡인다.
           if (intervalId) clearInterval(intervalId);
-          setProcessingUsername(null);
+          setPollingRequestId(null);
           // fetchRequests()는 시작할 때 setAlert(null)로 배너를 지운다. 순서를 안 지키고
           // 아래 setAlert보다 먼저 fetchRequests()를 fire-and-forget으로 부르면, 같은
           // 렌더 사이클에서 배치되면서 방금 세팅한 실패/성공 배너가 곧바로 지워져
@@ -127,7 +131,7 @@ const RequestManagementPage = () => {
       cancelled = true;
       clearInterval(intervalId);
     };
-  }, [provisioningTargetUsername]);
+  }, [provisioningTargetRequestId]);
 
   const fetchRequests = async () => {
     setIsLoading(true);
@@ -212,11 +216,11 @@ const RequestManagementPage = () => {
     if (processingRequestId !== null) return;
     setProcessingRequestId(request.request_id);
     if (newStatus === "FULFILLED") {
-      // 같은 사용자를 재승인할 때는 provisioningTargetUsername이 안 바뀌어서
+      // 같은 신청을 재승인할 때는 provisioningTargetRequestId가 안 바뀌어서
       // 폴링 useEffect가 재실행되지 않는다 — 이전 실패 시도의 진행 단계 메시지가
       // 첫 폴링(2초) 전까지 그대로 남아 보이는 걸 막기 위해 여기서 바로 지운다.
       setProvisioningStatus(null);
-      setProcessingUsername(request.ubuntu_username);
+      setPollingRequestId(request.request_id);
     }
     let isSubmitSuccess = false;
     try {
@@ -313,13 +317,13 @@ const RequestManagementPage = () => {
       }
     } finally {
       // processingRequestId는 버튼 중복 클릭 방지용이라 응답이 오면 바로 풀어도 된다.
-      // processingUsername은 여기서 무조건 지우지 않는다 — FULFILLED 제출이 성공했다면
+      // pollingRequestId는 여기서 무조건 지우지 않는다 — FULFILLED 제출이 성공했다면
       // 비동기 후처리가 아직 진행 중이므로, 진행 상태 폴링 배너가 계속 보여야 한다
       // (ready/failed로 끝나는 걸 폴링이 감지하면 그때 지운다). 제출 자체가 실패했거나
       // 거절(DENIED)인 경우엔 더 이상 폴링할 이유가 없으니 여기서 지운다.
       setProcessingRequestId(null);
       if (newStatus !== "FULFILLED" || !isSubmitSuccess) {
-        setProcessingUsername(null);
+        setPollingRequestId(null);
       }
     }
   };

--- a/src/pages/decs-console/admin/ContainerDetail.jsx
+++ b/src/pages/decs-console/admin/ContainerDetail.jsx
@@ -66,6 +66,9 @@ function ContainerDetail({ item, onBack, onRefetch }) {
   // 마이그레이션 진행 중일 때 config-server의 세세한 진행 단계를 폴링해서 보여준다.
   // 승인 요청 진행 상태(RequestManagementPage)와 동일한 패턴 — 조회 실패는
   // 마이그레이션 흐름 자체에 영향을 주지 않으므로 조용히 무시한다.
+  // podService.getProvisioningStatus의 인자명은 requestId지만, 마이그레이션 경로는
+  // 아직 config-server가 username 기준으로 진행 상황을 저장해서 여기서는 그대로
+  // username(c.name)을 넘긴다 — 승인(생성) 경로만 requestId로 바뀌었다.
   useEffect(() => {
     if (!isMigrating || !c?.name) {
       setMigrationStatus(null);

--- a/src/services/podService.js
+++ b/src/services/podService.js
@@ -6,7 +6,9 @@ export const podService = {
   getPodLogs: (podName, container) =>
     apiClient.get(`/api/admin/pods/${encodeURIComponent(podName)}/logs`, container ? { container } : undefined),
   getPodEvents: (podName) => apiClient.get(`/api/admin/pods/${encodeURIComponent(podName)}/events`),
-  getProvisioningStatus: (username) => apiClient.get(`/pod-status/pods/${encodeURIComponent(username)}/status`),
+  // 한 사용자가 컨테이너를 여러 개 동시에 신청할 수 있어, username이 아니라 requestId로
+  // 진행 상황을 조회한다 — 그래야 서로 다른 신청의 진행 상황이 안 섞인다.
+  getProvisioningStatus: (requestId) => apiClient.get(`/pod-status/requests/${encodeURIComponent(requestId)}/status`),
   getActiveContainers: () => apiClient.get("/api/admin/requests/containers"),
   getUsage: () => apiClient.get("/api/admin/requests/usage"),
 };


### PR DESCRIPTION
## 배경
admin_be/config-server가 Pod 생성 진행 상황을 requestId로 추적하도록 바뀌면서(admin_be PR #492, admin_infra PR #155), 사용자당 신청 1개 제한이 풀렸다. 프론트도 승인 처리 배너의 폴링 대상을 username 대신 requestId로 바꿔야 같은 사용자의 여러 신청이 안 섞인다.

## 변경 사항
- `podService.getProvisioningStatus`: username → requestId, URL도 `/pod-status/requests/{requestId}/status`로
- `RequestManagementPage.jsx`: 폴링 키를 `pollingRequestId`(신규)로 분리, `provisioningTargetRequestId` 계산
- `ContainerDetail.jsx`(마이그레이션 진행률 폴링)는 이번 범위 밖이라 그대로 두고 주석만 남김 — config-server의 마이그레이션 경로가 아직 username 기준이라 동작에 변화 없음

## 배포 순서
admin_be, admin_infra(config-server) PR을 먼저(또는 함께) 배포해야 합니다. 이 PR만 먼저 배포하면 프론트가 requestId를 config-server에 보내는데 config-server가 아직 username 기반이면 상태 조회가 계속 "생성 이력 없음"으로만 뜹니다(치명적이진 않지만 진행 배너가 무의미해짐).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Approval and provisioning progress is now tracked per request, allowing multiple container requests from the same user to be distinguished.
  - Progress polling continues after approval submission and ends when provisioning completes or encounters an error.
- **Bug Fixes**
  - Improved status updates for concurrent container requests to prevent progress from being mixed between requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->