### PR TITLE
fix: 진행 상황 폴링 주기 완화 및 DECS 대시보드 requestId 누락 수정

### DIFF
--- a/src/hooks/useDecsAdminData.js
+++ b/src/hooks/useDecsAdminData.js
@@ -52,8 +52,12 @@ export function useDecsAdminData() {
           Promise.allSettled(activeContainers.map((container) =>
             container.podName ? podService.getPod(container.podName) : Promise.resolve(null)
           )),
+          // getProvisioningStatus는 이제 requestId를 받는다(/pod-status/requests/{requestId}/status) —
+          // username을 넘기면 존재하지 않는 경로를 조회해 매번 실패한다. Pod가 아직 생성
+          // 중이라 getPod가 실패하는 컨테이너는 이 값으로 진행 단계(stage)를 대신 보여주므로,
+          // 여기가 계속 깨져 있으면 그런 컨테이너가 전부 "확인 불가"로만 보인다.
           Promise.allSettled(activeContainers.map((container) =>
-            container.ubuntuUsername ? podService.getProvisioningStatus(container.ubuntuUsername) : Promise.resolve(null)
+            container.requestId ? podService.getProvisioningStatus(container.requestId) : Promise.resolve(null)
           )),
         ]);
         if (cancelledRef.current) return;

--- a/src/pages/admin/RequestManagementPage.jsx
+++ b/src/pages/admin/RequestManagementPage.jsx
@@ -94,7 +94,7 @@ const RequestManagementPage = () => {
         if (cancelled) return;
         if (data) {
           // config-server가 단계 전환 사이에 message를 잠깐 비운 채 응답할 때가 있다.
-          // 그대로 반영하면 "(현재 단계: ...)" 문구가 매 폴링(1초)마다 사라졌다
+          // 그대로 반영하면 "(현재 단계: ...)" 문구가 매 폴링(3초)마다 사라졌다
           // 나타나면서 배너 높이가 흔들려 깜빡이는 것처럼 보인다 — message가 없는
           // 응답에서는 직전에 표시하던 값을 그대로 유지한다.
           setProvisioningStatus((prev) => ({ ...data, message: data.message || prev?.message || null }));
@@ -104,7 +104,7 @@ const RequestManagementPage = () => {
         // 폴링으로 확인한 뒤에야 목록을 새로고침하고 최종 결과를 안내한다.
         if (data?.stage === "ready" || data?.stage === "failed") {
           // stage는 ready/failed로 끝난 뒤에도 config-server에 계속 그대로 남아있다.
-          // 여기서 멈추지 않으면 다음 폴링(1초 뒤)에도 같은 stage를 또 감지해서
+          // 여기서 멈추지 않으면 다음 폴링(3초 뒤)에도 같은 stage를 또 감지해서
           // fetchRequests()와 배너 갱신이 끝없이 반복되며 화면이 계속 깜빡인다.
           if (intervalId) clearInterval(intervalId);
           setPollingRequestId(null);
@@ -126,7 +126,7 @@ const RequestManagementPage = () => {
       }
     };
     poll();
-    intervalId = setInterval(poll, 1000);
+    intervalId = setInterval(poll, 3000);
     return () => {
       cancelled = true;
       clearInterval(intervalId);
@@ -218,7 +218,7 @@ const RequestManagementPage = () => {
     if (newStatus === "FULFILLED") {
       // 같은 신청을 재승인할 때는 provisioningTargetRequestId가 안 바뀌어서
       // 폴링 useEffect가 재실행되지 않는다 — 이전 실패 시도의 진행 단계 메시지가
-      // 첫 폴링(2초) 전까지 그대로 남아 보이는 걸 막기 위해 여기서 바로 지운다.
+      // 첫 폴링(3초) 전까지 그대로 남아 보이는 걸 막기 위해 여기서 바로 지운다.
       setProvisioningStatus(null);
       setPollingRequestId(request.request_id);
     }

--- a/src/pages/decs-console/admin/ContainerDetail.jsx
+++ b/src/pages/decs-console/admin/ContainerDetail.jsx
@@ -85,7 +85,7 @@ function ContainerDetail({ item, onBack, onRefetch }) {
       } catch {
         // ignore
       } finally {
-        if (!cancelled) timeoutId = setTimeout(poll, 1000);
+        if (!cancelled) timeoutId = setTimeout(poll, 3000);
       }
     };
     poll();


### PR DESCRIPTION
## 배경

승인/마이그레이션 진행 상황 폴링(1초 간격)이 버벅인다는 피드백으로 조사하다가, DECS 관리자 대시보드에 실제로 살아있는 버그를 하나 더 발견했다.

## 변경 사항

- `RequestManagementPage.jsx`, `ContainerDetail.jsx`: 진행 상황 폴링 주기 1000ms → 3000ms.
- `useDecsAdminData.js`: 활성 컨테이너 목록의 `getProvisioningStatus` 호출이 여전히 `username`을 넘기고 있었음 — `9fbae46`에서 이 함수가 `requestId`를 받아 `/pod-status/requests/{requestId}/status`를 호출하도록 바뀌었는데 이 호출부만 누락됨. 결과적으로 Pod 생성 중이라 `getPod`가 실패하는 컨테이너는 진행 단계 대체 조회도 항상 실패해서 전부 "확인 불가"로 보였음. `container.requestId`로 교체.

## 테스트

- `npm run build`, `eslint` 통과.

## Test plan

- [x] 빌드/린트 통과
- [ ] 스테이징에서 승인 처리 중 배너가 3초 간격으로 갱신되는지, DECS 대시보드에서 생성 중인 컨테이너가 "확인 불가" 대신 실제 단계를 보여주는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provisioning-status accuracy by checking requests using their request IDs.
  * Preserved provisioning-stage status for containers that have not yet been created.

* **Performance**
  * Reduced the frequency of provisioning and migration status checks to lessen unnecessary polling while maintaining status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->