### PR TITLE
fix: 내 컨테이너 목록에서 여러 컨테이너가 구분 안 되던 문제 수정

### DIFF
--- a/src/hooks/useDecsUserData.js
+++ b/src/hooks/useDecsUserData.js
@@ -96,10 +96,15 @@ function buildGpuOptions(gpuTypes) {
 function buildServerVm(dto) {
   const vm = mapUserServer(dto);
   const serverName = dto.resourceGroup?.serverName ?? "";
+  // 웹 계정 하나당 우분투 유저네임이 하나로 고정되면서, 한 사용자가 컨테이너를 여러 개
+  // 동시에 가질 때 ubuntuUsername만으로는 서로 구분이 안 된다 — 신청 시 적어낸 사용
+  // 목적이 그나마 본인이 알아볼 수 있는 유일한 값이라 이걸 제목으로 쓴다.
+  const usagePurpose = dto.usagePurpose ?? dto.usage_purpose;
 
   return {
     requestId: vm.id,
     ubuntuUsername: dto.ubuntuUsername ?? "—",
+    usagePurpose,
     image: vm.image,
     expiresAt: vm.expiresAt,
     gpuName: serverName || vm.gpuName,
@@ -107,7 +112,7 @@ function buildServerVm(dto) {
     statusType: vm.statusType ?? "success",
     statusLabel: vm.statusLabel ?? "사용 가능",
     jobBadge: `내 서버 · ${serverName || vm.gpuName}`,
-    jobTitle: "내 서버",
+    jobTitle: usagePurpose || "내 서버",
     daysLeft: vm.daysLeft ?? daysLeft(dto.expiresAt),
     expiresText: formatExpiresText(vm.expiresAt),
     sshCommand: vm.sshCommand || "—",

--- a/src/pages/decs-console/user/UserContainerDetail.jsx
+++ b/src/pages/decs-console/user/UserContainerDetail.jsx
@@ -103,7 +103,10 @@ function UserContainerDetail({ onBack, onExtend, servers = [] }) {
                 }}
               >
                 <div>
-                  <div style={{ fontWeight: 600, color: "var(--decs-text-heading)" }}>{item.ubuntuUsername}</div>
+                  {/* 내 컨테이너 전부 같은 우분투 유저네임을 쓰므로(웹 계정당 하나로 고정),
+                      그걸 제목으로 쓰면 여러 개일 때 전혀 구분이 안 된다 — 신청 시 적어낸
+                      사용 목적을 대신 쓴다. */}
+                  <div style={{ fontWeight: 600, color: "var(--decs-text-heading)" }}>{item.jobTitle}</div>
                   <div style={{ fontSize: "var(--decs-fs-body-s)", color: "var(--decs-text-secondary)" }}>
                     {item.gpuName}{item.gpuSpec ? ` · ${item.gpuSpec}` : ""} · {item.expiresText}
                   </div>


### PR DESCRIPTION
## 배경

웹 계정 하나당 우분투 유저네임이 하나로 고정되면서(v0.5), 사용자가 컨테이너를 여러 개 동시에 가질 때 "내 컨테이너 목록" 카드 제목이 전부 같은 유저네임으로 표시돼 서로 구분이 안 됐다.

## 변경 사항

신청 시 적어낸 사용 목적(`usagePurpose`)이 이미 백엔드에서 내려오고 있었는데 이 화면만 안 쓰고 있었다 — `jobTitle`을 "내 서버" 고정 문구 대신 사용 목적으로 채우고, 목록 카드 제목도 유저네임 대신 이걸 쓰도록 변경.

## 테스트

- eslint 0 errors, `npm run build` 통과.
- CodeRabbit 리뷰 통과 (findings: 0).