### PR TITLE
fix: 관리자 콘솔 컨테이너 개별 삭제가 같은 계정의 다른 컨테이너까지 지우던 문제 수정

### DIFF
--- a/src/pages/decs-console/admin/ContainerDetail.jsx
+++ b/src/pages/decs-console/admin/ContainerDetail.jsx
@@ -5,7 +5,6 @@ import {
   Button, Modal, Alert, FormField, Input,
 } from "../../../design-system";
 import { requestService } from "../../../services/requestService";
-import userService from "../../../services/userService";
 import { nodeService } from "../../../services/nodeService";
 import { podService } from "../../../services/podService";
 
@@ -199,9 +198,13 @@ function ContainerDetail({ item, onBack, onRefetch }) {
     setDeleteError(null);
     setIsDeleting(true);
     try {
-      await userService.deleteUbuntuAccount(c.name);
+      await requestService.deleteContainer(c.requestId);
+      setDeleteOpen(false);
       onRefetch?.();
-      onBack();
+      setAlert({ type: "success", message: `컨테이너 "${c.name}"을(를) 삭제했습니다.` });
+      // 삭제된 컨테이너는 더 이상 존재하지 않아 이 페이지에 계속 머물면 로그/이벤트 탭이
+      // 깨진 상태로 남는다 — 성공 메시지를 잠깐 보여준 뒤 목록으로 돌아간다.
+      setTimeout(() => onBack(), 1500);
     } catch (error) {
       console.error("Failed to delete container:", error);
       setDeleteError(error.message || "컨테이너 삭제에 실패했습니다.");

--- a/src/services/requestService.js
+++ b/src/services/requestService.js
@@ -43,6 +43,14 @@ export const requestService = {
       signal: AbortSignal.timeout(600_000),
     }),
 
+  // 컨테이너(신청) 개별 삭제 — userService.deleteUbuntuAccount(username)는 그 유저네임에
+  // 딸린 살아있는 신청을 전부 지우므로, 한 사용자가 컨테이너를 여러 개 가진 상태에서 이걸
+  // 개별 삭제에 쓰면 안 된다. requestId로 정확히 이 컨테이너 하나만 지운다.
+  deleteContainer: (requestId) =>
+    apiClient.delete(`/api/admin/requests/${requestId}`, {
+      signal: AbortSignal.timeout(600_000),
+    }),
+
   getGpuTypes: () => apiClient.get("/api/resources/gpu-types"),
   getGroups: () => apiClient.get("/api/groups"),
   checkUbuntuUsername: (username) =>

--- a/src/utils/decsMapper.js
+++ b/src/utils/decsMapper.js
@@ -102,7 +102,11 @@ export function mapAdminContainer(dto) {
     : "—";
 
   return {
-    id: String(dto.ubuntuUsername ?? dto.userId),
+    // 한 사용자가 컨테이너를 여러 개 동시에 가질 수 있어 ubuntuUsername은 행마다 겹칠 수
+    // 있다 — id가 겹치면 목록의 Table trackBy와 상세 페이지 라우팅(/admin/containers/:id)이
+    // 같은 유저의 다른 컨테이너를 클릭해도 항상 같은(첫 번째로 매칭되는) 컨테이너를 가리켜서,
+    // 엉뚱한 컨테이너를 보거나 지우게 된다. requestId는 컨테이너 하나당 유일하므로 이걸로 쓴다.
+    id: String(dto.requestId ?? dto.ubuntuUsername ?? dto.userId),
     requestId: dto.requestId,
     name: dto.ubuntuUsername ?? dto.userName ?? "—",
     user: dto.ubuntuUsername ?? dto.userName ?? "—",


### PR DESCRIPTION
## Summary
- 컨테이너 상세 페이지 삭제 버튼이 계정 전체 삭제(username 단위) 엔드포인트를 호출하고 있어, 한 사용자가 컨테이너를 여러 개 가진 경우 하나만 지우려 해도 나머지까지 함께 삭제되던 문제를 수정했습니다.
- requestId 기준의 개별 삭제 엔드포인트(admin_be #502)를 호출하도록 변경하고, 삭제 완료 알림을 추가했습니다.
- 컨테이너 목록/상세 라우팅에 쓰이던 id가 ubuntuUsername이라 같은 사용자의 컨테이너끼리 겹치던 문제도 requestId 기준으로 수정했습니다.

## Test plan
- [ ] admin_be #502 PR과 함께 배포 후, 컨테이너를 2개 이상 가진 사용자로 하나만 삭제해 나머지가 남아있는지 확인
- [ ] 컨테이너 목록에서 같은 사용자의 서로 다른 행을 클릭했을 때 각각 올바른 상세로 연결되는지 확인
- [ ] 삭제 성공 시 알림이 표시되는지 확인

Closes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed container deletion to remove the selected container rather than an associated account.
  * Added a longer timeout for container deletion requests to support extended processing times.
  * Corrected container identification to prioritize the request ID.
  * Improved post-deletion feedback by showing a success message and returning to the container list after a brief delay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->